### PR TITLE
Unrecruitable flag specific to the pokemon + others

### DIFF
--- a/PMDC/Dungeon/GameEffects/BattleEvent.cs
+++ b/PMDC/Dungeon/GameEffects/BattleEvent.cs
@@ -7167,6 +7167,58 @@ namespace PMDC.Dungeon
     }
 
     [Serializable]
+    public class HasStatusNeededEvent : BattleEvent
+    {
+        [JsonConverter(typeof(StatusListConverter))]
+        [DataType(1, DataManager.DataType.Status, false)]
+        public List<string> Statuses;
+        public bool AffectTarget;
+        public List<BattleEvent> BaseEvents;
+
+        public HasStatusNeededEvent() { Statuses = new List<string>(); BaseEvents = new List<BattleEvent>(); }
+        public HasStatusNeededEvent(bool affectTarget, string[] statuses, params BattleEvent[] effects) : this()
+        {
+            AffectTarget = affectTarget;
+            foreach (string statusId in statuses)
+                Statuses.Add(statusId);
+            foreach (BattleEvent effect in effects)
+                BaseEvents.Add(effect);
+        }
+        protected HasStatusNeededEvent(HasStatusNeededEvent other) : this()
+        {
+            AffectTarget = other.AffectTarget;
+            foreach (string statusId in other.Statuses)
+                Statuses.Add(statusId);
+            foreach (BattleEvent battleEffect in other.BaseEvents)
+                BaseEvents.Add((BattleEvent)battleEffect.Clone());
+        }
+        public override GameEvent Clone() { return new HasStatusNeededEvent(this); }
+
+        public override IEnumerator<YieldInstruction> Apply(GameEventOwner owner, Character ownerChar, BattleContext context)
+        {
+            Character target = (AffectTarget ? context.Target : context.User);
+
+            bool hasStatus = false;
+            foreach (StatusEffect status in target.IterateStatusEffects())
+            {
+                if(Statuses.Contains(status.ID))
+                {
+                    hasStatus = true;
+                    break;
+                }
+            }
+
+            if(hasStatus)
+            {
+                foreach (BattleEvent battleEffect in BaseEvents)
+                    yield return CoroutineManager.Instance.StartCoroutine(battleEffect.Apply(owner, ownerChar, context));
+            }
+
+            yield break;
+        }
+    }
+
+    [Serializable]
     public class StatusNeededEvent : BattleEvent
     {
         [JsonConverter(typeof(StatusConverter))]

--- a/PMDC/Dungeon/GameEffects/BattleEvent.cs
+++ b/PMDC/Dungeon/GameEffects/BattleEvent.cs
@@ -2736,52 +2736,43 @@ namespace PMDC.Dungeon
     }
 
     [Serializable]
-    public class MultiplyElementInMajorStatusEvent : BattleEvent
+    public class MultiplyDamageInMajorStatusEvent : BattleEvent
     {
-        [JsonConverter(typeof(ElementConverter))]
-        [DataType(0, DataManager.DataType.Element, false)]
-        public string MultElement;
         public int Numerator;
         public int Denominator;
         public bool AffectTarget;
 
-        public MultiplyElementInMajorStatusEvent() { MultElement = ""; }
+        public MultiplyDamageInMajorStatusEvent() { }
 
-        public MultiplyElementInMajorStatusEvent(string element, int numerator, int denominator, bool affectTarget)
+        public MultiplyDamageInMajorStatusEvent(string element, int numerator, int denominator, bool affectTarget)
         {
-            MultElement = element;
             Numerator = numerator;
             Denominator = denominator;
             AffectTarget = affectTarget;
         }
-        protected MultiplyElementInMajorStatusEvent(MultiplyElementInMajorStatusEvent other)
+        protected MultiplyDamageInMajorStatusEvent(MultiplyDamageInMajorStatusEvent other)
         {
-            MultElement = other.MultElement;
             Numerator = other.Numerator;
             Denominator = other.Denominator;
             AffectTarget = other.AffectTarget;
         }
-        public override GameEvent Clone() { return new MultiplyElementInMajorStatusEvent(this); }
+        public override GameEvent Clone() { return new MultiplyDamageInMajorStatusEvent(this); }
 
         public override IEnumerator<YieldInstruction> Apply(GameEventOwner owner, Character ownerChar, BattleContext context)
         {
             Character target = (AffectTarget ? context.Target : context.User);
 
-            if (MultElement == context.Data.Element)
+            foreach (StatusEffect status in target.IterateStatusEffects())
             {
-                foreach (StatusEffect status in target.IterateStatusEffects())
+                if (status.StatusStates.Contains<MajorStatusState>())
                 {
-                    if (status.StatusStates.Contains<MajorStatusState>())
-                    {
-                        context.AddContextStateMult<DmgMult>(false, Numerator, Denominator);
-                        break;
-                    }
+                    context.AddContextStateMult<DmgMult>(false, Numerator, Denominator);
+                    break;
                 }
             }
             yield break;
         }
     }
-
 
     [Serializable]
     public class BetterOddsEvent : BattleEvent

--- a/PMDC/Dungeon/GameEffects/BattleEvent.cs
+++ b/PMDC/Dungeon/GameEffects/BattleEvent.cs
@@ -2738,24 +2738,25 @@ namespace PMDC.Dungeon
     [Serializable]
     public class MultiplyElementInMajorStatusEvent : BattleEvent
     {
-        [JsonConverter(typeof(ElementListConverter))]
+        [JsonConverter(typeof(ElementConverter))]
         [DataType(0, DataManager.DataType.Element, false)]
-        public List<string> MultElements;
+        public string MultElement;
         public int Numerator;
         public int Denominator;
         public bool AffectTarget;
 
-        public MultiplyElementInMajorStatusEvent() { MultElements = new List<string>(); }
-        public MultiplyElementInMajorStatusEvent(string element, int numerator, int denominator, bool affectTarget) : this()
+        public MultiplyElementInMajorStatusEvent() { MultElement = ""; }
+
+        public MultiplyElementInMajorStatusEvent(string element, int numerator, int denominator, bool affectTarget)
         {
-            MultElements.Add(element);
+            MultElement = element;
             Numerator = numerator;
             Denominator = denominator;
             AffectTarget = affectTarget;
         }
         protected MultiplyElementInMajorStatusEvent(MultiplyElementInMajorStatusEvent other)
         {
-            MultElements = new List<string>(other.MultElements);
+            MultElement = other.MultElement;
             Numerator = other.Numerator;
             Denominator = other.Denominator;
             AffectTarget = other.AffectTarget;
@@ -2766,7 +2767,7 @@ namespace PMDC.Dungeon
         {
             Character target = (AffectTarget ? context.Target : context.User);
 
-            if (MultElements.Contains(context.Data.Element))
+            if (MultElement == context.Data.Element)
             {
                 foreach (StatusEffect status in target.IterateStatusEffects())
                 {
@@ -4085,25 +4086,27 @@ namespace PMDC.Dungeon
     [Serializable]
     public class AddElementRangeEvent : BattleEvent
     {
-        [JsonConverter(typeof(ElementListConverter))]
+        [JsonConverter(typeof(ElementConverter))]
         [DataType(0, DataManager.DataType.Element, false)]
-        public List<string> AffectedElements;
+        public string AffectedElement;
         public int Range;
 
-        public AddElementRangeEvent() { }
-        public AddElementRangeEvent(int range)
+        public AddElementRangeEvent() { AffectedElement = ""; }
+        public AddElementRangeEvent(string element, int range)
         {
+            AffectedElement = element;
             Range = range;
         }
         protected AddElementRangeEvent(AddElementRangeEvent other)
         {
+            AffectedElement = other.AffectedElement;
             Range = other.Range;
         }
         public override GameEvent Clone() { return new AddElementRangeEvent(this); }
 
         public override IEnumerator<YieldInstruction> Apply(GameEventOwner owner, Character ownerChar, BattleContext context)
         {
-            if (AffectedElements.Contains(context.Data.Element))
+            if (AffectedElement == context.Data.Element)
             {
                 context.RangeMod += Range;
             }
@@ -14471,7 +14474,7 @@ namespace PMDC.Dungeon
         {
             yield return new WaitForFrames(GameManager.Instance.ModifyBattleSpeed(30));
 
-            if (!(context.Target.MemberTeam is MonsterTeam) || ((MonsterTeam)context.Target.MemberTeam).Unrecruitable)
+            if (context.Target.Unrecruitable)
             {
                 DungeonScene.Instance.LogMsg(String.Format(new StringKey("MSG_CANT_RECRUIT").ToLocal(), context.Target.GetDisplayName(false)));
                 GameManager.Instance.BattleSE("DUN_Miss");

--- a/PMDC/Dungeon/GameEffects/BattleEvent.cs
+++ b/PMDC/Dungeon/GameEffects/BattleEvent.cs
@@ -4074,36 +4074,7 @@ namespace PMDC.Dungeon
             yield break;
         }
     }
-    [Serializable]
-    public class AddElementRangeEvent : BattleEvent
-    {
-        [JsonConverter(typeof(ElementConverter))]
-        [DataType(0, DataManager.DataType.Element, false)]
-        public string AffectedElement;
-        public int Range;
-
-        public AddElementRangeEvent() { AffectedElement = ""; }
-        public AddElementRangeEvent(string element, int range)
-        {
-            AffectedElement = element;
-            Range = range;
-        }
-        protected AddElementRangeEvent(AddElementRangeEvent other)
-        {
-            AffectedElement = other.AffectedElement;
-            Range = other.Range;
-        }
-        public override GameEvent Clone() { return new AddElementRangeEvent(this); }
-
-        public override IEnumerator<YieldInstruction> Apply(GameEventOwner owner, Character ownerChar, BattleContext context)
-        {
-            if (AffectedElement == context.Data.Element)
-            {
-                context.RangeMod += Range;
-            }
-            yield break;
-        }
-    }
+    
     [Serializable]
     public class BoostCriticalEvent : BattleEvent
     {

--- a/PMDC/Dungeon/GameEffects/BattleEvent.cs
+++ b/PMDC/Dungeon/GameEffects/BattleEvent.cs
@@ -4083,6 +4083,34 @@ namespace PMDC.Dungeon
         }
     }
     [Serializable]
+    public class AddElementRangeEvent : BattleEvent
+    {
+        [JsonConverter(typeof(ElementListConverter))]
+        [DataType(0, DataManager.DataType.Element, false)]
+        public List<string> AffectedElements;
+        public int Range;
+
+        public AddElementRangeEvent() { }
+        public AddElementRangeEvent(int range)
+        {
+            Range = range;
+        }
+        protected AddElementRangeEvent(AddElementRangeEvent other)
+        {
+            Range = other.Range;
+        }
+        public override GameEvent Clone() { return new AddElementRangeEvent(this); }
+
+        public override IEnumerator<YieldInstruction> Apply(GameEventOwner owner, Character ownerChar, BattleContext context)
+        {
+            if (AffectedElements.Contains(context.Data.Element))
+            {
+                context.RangeMod += Range;
+            }
+            yield break;
+        }
+    }
+    [Serializable]
     public class BoostCriticalEvent : BattleEvent
     {
         public int AddCrit;

--- a/PMDC/Dungeon/GameEffects/BattleEvent.cs
+++ b/PMDC/Dungeon/GameEffects/BattleEvent.cs
@@ -2735,6 +2735,52 @@ namespace PMDC.Dungeon
         }
     }
 
+    [Serializable]
+    public class MultiplyElementInMajorStatusEvent : BattleEvent
+    {
+        [JsonConverter(typeof(ElementListConverter))]
+        [DataType(0, DataManager.DataType.Element, false)]
+        public List<string> MultElements;
+        public int Numerator;
+        public int Denominator;
+        public bool AffectTarget;
+
+        public MultiplyElementInMajorStatusEvent() { MultElements = new List<string>(); }
+        public MultiplyElementInMajorStatusEvent(string element, int numerator, int denominator, bool affectTarget) : this()
+        {
+            MultElements.Add(element);
+            Numerator = numerator;
+            Denominator = denominator;
+            AffectTarget = affectTarget;
+        }
+        protected MultiplyElementInMajorStatusEvent(MultiplyElementInMajorStatusEvent other)
+        {
+            MultElements = new List<string>(other.MultElements);
+            Numerator = other.Numerator;
+            Denominator = other.Denominator;
+            AffectTarget = other.AffectTarget;
+        }
+        public override GameEvent Clone() { return new MultiplyElementInMajorStatusEvent(this); }
+
+        public override IEnumerator<YieldInstruction> Apply(GameEventOwner owner, Character ownerChar, BattleContext context)
+        {
+            Character target = (AffectTarget ? context.Target : context.User);
+
+            if (MultElements.Contains(context.Data.Element))
+            {
+                foreach (StatusEffect status in target.IterateStatusEffects())
+                {
+                    if (status.StatusStates.Contains<MajorStatusState>())
+                    {
+                        context.AddContextStateMult<DmgMult>(false, Numerator, Denominator);
+                        break;
+                    }
+                }
+            }
+            yield break;
+        }
+    }
+
 
     [Serializable]
     public class BetterOddsEvent : BattleEvent

--- a/PMDC/Dungeon/GameEffects/BattleEvent.cs
+++ b/PMDC/Dungeon/GameEffects/BattleEvent.cs
@@ -13943,11 +13943,12 @@ namespace PMDC.Dungeon
     [Serializable]
     public class LinkBoxEvent : BattleEvent
     {
+        public bool IncludePreEvolutions;
         public LinkBoxEvent() { }
         public override GameEvent Clone() { return new LinkBoxEvent(); }
         public override IEnumerator<YieldInstruction> Apply(GameEventOwner owner, Character ownerChar, BattleContext context)
         {
-            List<string> forgottenMoves = context.User.GetRelearnableSkills();
+            List<string> forgottenMoves = context.User.GetRelearnableSkills(IncludePreEvolutions);
 
             if (DataManager.Instance.CurrentReplay != null)// this block of code will never evaluate to true AND have UI read back -1 (cancel)
             {

--- a/PMDC/Dungeon/GameEffects/SingleCharEvent.cs
+++ b/PMDC/Dungeon/GameEffects/SingleCharEvent.cs
@@ -1148,6 +1148,38 @@ namespace PMDC.Dungeon
     }
 
     [Serializable]
+    public class SetTrapSingleEvent : SingleCharEvent
+    {
+        [JsonConverter(typeof(TileConverter))]
+        [DataType(0, DataManager.DataType.Tile, false)]
+        public string TrapID;
+
+        public SetTrapSingleEvent() { }
+        public SetTrapSingleEvent(string trapID)
+        {
+            TrapID = trapID;
+        }
+        protected SetTrapSingleEvent(SetTrapSingleEvent other)
+        {
+            TrapID = other.TrapID;
+        }
+        public override GameEvent Clone() { return new SetTrapSingleEvent(this); }
+
+        public override IEnumerator<YieldInstruction> Apply(GameEventOwner owner, Character ownerChar, Character character)
+        {
+            Tile tile = ZoneManager.Instance.CurrentMap.GetTile(character.CharLoc);
+            if (tile == null)
+                yield break;
+
+            if (tile.Data.GetData().BlockType == TerrainData.Mobility.Passable && String.IsNullOrEmpty(tile.Effect.ID))
+            {
+                tile.Effect = new EffectTile(TrapID, true, tile.Effect.TileLoc);
+                tile.Effect.Owner = ZoneManager.Instance.CurrentMap.GetTileOwner(character);
+            }
+        }
+    }
+
+    [Serializable]
     public abstract class HandoutExpEvent : SingleCharEvent
     {
         public override IEnumerator<YieldInstruction> Apply(GameEventOwner owner, Character ownerChar, Character character)

--- a/PMDC/Dungeon/GameEffects/SkillState.cs
+++ b/PMDC/Dungeon/GameEffects/SkillState.cs
@@ -43,4 +43,10 @@ namespace PMDC.Dungeon
         public JawState() { }
         public override GameplayState Clone() { return new JawState(); }
     }
+    [Serializable]
+    public class BladeState : SkillState
+    {
+        public BladeState() { }
+        public override GameplayState Clone() { return new BladeState(); }
+    }
 }

--- a/PMDC/LevelGen/Spawning/MobSpawn/MobSpawnExtra.cs
+++ b/PMDC/LevelGen/Spawning/MobSpawn/MobSpawnExtra.cs
@@ -431,7 +431,7 @@ namespace PMDC.LevelGen
         public override void ApplyFeature(IMobSpawnMap map, Character newChar)
         {
             if (newChar.MemberTeam is MonsterTeam)
-                ((MonsterTeam)newChar.MemberTeam).Unrecruitable = true;
+                newChar.Unrecruitable = true;
             newChar.BaseForm.Skin = DataManager.Instance.DefaultSkin;
         }
 


### PR DESCRIPTION
- MultiplyElementInMajorStatusEvent and BladeState
- Added AddElementRangeEvent (adds range if the move is of a certain type)
- Removed element from MultiplyElementInMajorStatusEvent and the event is now called MultiplyDamageInMajorStatusEvent
- Removed AddElementRange since it can also be broken down (ElementNeeded and AddRange)
- Added HasStatusNeededEvent, which allows the user to specify exactly which status effects are needed; can have members
- Added SetTrapSingleEvent inheriting from SingleCharEvent
- Collapsed MultiplyDamageInMajorStatusEvent into MajorStatusPowerEvent and HasStatusNeededEvent into GiveStatusNeededEvent