### PR TITLE
Adds visible houses and no house entrances

### DIFF
--- a/PMDC/Dungeon/GameEffects/SingleCharEvent.cs
+++ b/PMDC/Dungeon/GameEffects/SingleCharEvent.cs
@@ -4874,22 +4874,7 @@ namespace PMDC.Dungeon
     [Serializable]
     public class ChestEvent : SingleCharEvent
     {
-        /// <summary>
-        /// The animation to play when the chest opens.
-        /// Defaults to Chest_Open.
-        /// </summary>
-        public AnimData ChestAnimation;
-
-        /// <summary>
-        /// The empty chest tile to spawn.
-        /// Defaults to chest_house_empty.
-        /// </summary>
-        [DataType(0, DataManager.DataType.Tile, true)]
-        public string ChestEmptyTile;
-
-        public ChestEvent()
-        {
-        }
+        public ChestEvent() { }
         public override GameEvent Clone() { return new ChestEvent(); }
 
         public override IEnumerator<YieldInstruction> Apply(GameEventOwner owner, Character ownerChar, SingleCharContext context)
@@ -4905,7 +4890,9 @@ namespace PMDC.Dungeon
             Loc baseLoc = effectTile.TileLoc;
             {
                 Tile chest = ZoneManager.Instance.CurrentMap.Tiles[baseLoc.X][baseLoc.Y];
-                SingleEmitter emitter = new SingleEmitter(ChestAnimation);
+                SingleEmitter emitter = new SingleEmitter(new AnimData("Chest_Open", 8));
+                if (chest.Effect.ID.Equals("chest_house_full"))
+                    emitter = new SingleEmitter(new AnimData("Chest_Red_Open", 8));
                 emitter.SetupEmit(baseLoc * GraphicsManager.TileSize + new Loc(GraphicsManager.TileSize / 2), baseLoc * GraphicsManager.TileSize + new Loc(GraphicsManager.TileSize / 2), Dir8.Down);
                 DungeonScene.Instance.CreateAnim(emitter, DrawLayer.NoDraw);
             }
@@ -4930,7 +4917,10 @@ namespace PMDC.Dungeon
             //change the chest to open
             Tile tile = ZoneManager.Instance.CurrentMap.Tiles[baseLoc.X][baseLoc.Y];
             if (tile.Effect == owner)
-                tile.Effect = new EffectTile(ChestEmptyTile, true, tile.Effect.TileLoc);// magic number
+                if (tile.Effect.ID.Equals("chest_house_full"))
+                    tile.Effect = new EffectTile("chest_house_empty", true, tile.Effect.TileLoc);
+                else
+                    tile.Effect = new EffectTile("chest_empty", true, tile.Effect.TileLoc);// magic number
 
             //spawn the items
             Rect bounds = ((EffectTile)owner).TileStates.GetWithDefault<BoundsState>().Bounds;

--- a/PMDC/Dungeon/GameEffects/SingleCharEvent.cs
+++ b/PMDC/Dungeon/GameEffects/SingleCharEvent.cs
@@ -4881,8 +4881,8 @@ namespace PMDC.Dungeon
         public AnimData ChestAnimation;
 
         /// <summary>
-        /// The empty chest tile to spawn.
-        /// Defaults to chest_house_empty.
+        /// The empty chest tile to spawn after the chest is opened.
+        /// Defaults to chest_empty.
         /// </summary>
         [DataType(0, DataManager.DataType.Tile, true)]
         public string ChestEmptyTile;

--- a/PMDC/Dungeon/GameEffects/SingleCharEvent.cs
+++ b/PMDC/Dungeon/GameEffects/SingleCharEvent.cs
@@ -4889,7 +4889,10 @@ namespace PMDC.Dungeon
             //open chest animation/sound
             Loc baseLoc = effectTile.TileLoc;
             {
+                Tile chest = ZoneManager.Instance.CurrentMap.Tiles[baseLoc.X][baseLoc.Y];
                 SingleEmitter emitter = new SingleEmitter(new AnimData("Chest_Open", 8));
+                if (chest.Effect.ID.Equals("chest_house_full"))
+                    emitter = new SingleEmitter(new AnimData("Chest_Red_Open", 8));
                 emitter.SetupEmit(baseLoc * GraphicsManager.TileSize + new Loc(GraphicsManager.TileSize / 2), baseLoc * GraphicsManager.TileSize + new Loc(GraphicsManager.TileSize / 2), Dir8.Down);
                 DungeonScene.Instance.CreateAnim(emitter, DrawLayer.NoDraw);
             }
@@ -4914,7 +4917,10 @@ namespace PMDC.Dungeon
             //change the chest to open
             Tile tile = ZoneManager.Instance.CurrentMap.Tiles[baseLoc.X][baseLoc.Y];
             if (tile.Effect == owner)
-                tile.Effect = new EffectTile("chest_empty", true, tile.Effect.TileLoc);// magic number
+                if (tile.Effect.ID.Equals("chest_house_full"))
+                    tile.Effect = new EffectTile("chest_house_empty", true, tile.Effect.TileLoc);
+                else
+                    tile.Effect = new EffectTile("chest_empty", true, tile.Effect.TileLoc);// magic number
 
             //spawn the items
             Rect bounds = ((EffectTile)owner).TileStates.GetWithDefault<BoundsState>().Bounds;

--- a/PMDC/Dungeon/GameEffects/SingleCharEvent.cs
+++ b/PMDC/Dungeon/GameEffects/SingleCharEvent.cs
@@ -4874,7 +4874,22 @@ namespace PMDC.Dungeon
     [Serializable]
     public class ChestEvent : SingleCharEvent
     {
-        public ChestEvent() { }
+        /// <summary>
+        /// The animation to play when the chest opens.
+        /// Defaults to Chest_Open.
+        /// </summary>
+        public AnimData ChestAnimation;
+
+        /// <summary>
+        /// The empty chest tile to spawn.
+        /// Defaults to chest_house_empty.
+        /// </summary>
+        [DataType(0, DataManager.DataType.Tile, true)]
+        public string ChestEmptyTile;
+
+        public ChestEvent()
+        {
+        }
         public override GameEvent Clone() { return new ChestEvent(); }
 
         public override IEnumerator<YieldInstruction> Apply(GameEventOwner owner, Character ownerChar, SingleCharContext context)
@@ -4890,9 +4905,7 @@ namespace PMDC.Dungeon
             Loc baseLoc = effectTile.TileLoc;
             {
                 Tile chest = ZoneManager.Instance.CurrentMap.Tiles[baseLoc.X][baseLoc.Y];
-                SingleEmitter emitter = new SingleEmitter(new AnimData("Chest_Open", 8));
-                if (chest.Effect.ID.Equals("chest_house_full"))
-                    emitter = new SingleEmitter(new AnimData("Chest_Red_Open", 8));
+                SingleEmitter emitter = new SingleEmitter(ChestAnimation);
                 emitter.SetupEmit(baseLoc * GraphicsManager.TileSize + new Loc(GraphicsManager.TileSize / 2), baseLoc * GraphicsManager.TileSize + new Loc(GraphicsManager.TileSize / 2), Dir8.Down);
                 DungeonScene.Instance.CreateAnim(emitter, DrawLayer.NoDraw);
             }
@@ -4917,10 +4930,7 @@ namespace PMDC.Dungeon
             //change the chest to open
             Tile tile = ZoneManager.Instance.CurrentMap.Tiles[baseLoc.X][baseLoc.Y];
             if (tile.Effect == owner)
-                if (tile.Effect.ID.Equals("chest_house_full"))
-                    tile.Effect = new EffectTile("chest_house_empty", true, tile.Effect.TileLoc);
-                else
-                    tile.Effect = new EffectTile("chest_empty", true, tile.Effect.TileLoc);// magic number
+                tile.Effect = new EffectTile(ChestEmptyTile, true, tile.Effect.TileLoc);// magic number
 
             //spawn the items
             Rect bounds = ((EffectTile)owner).TileStates.GetWithDefault<BoundsState>().Bounds;

--- a/PMDC/Dungeon/GameEffects/UniversalState.cs
+++ b/PMDC/Dungeon/GameEffects/UniversalState.cs
@@ -243,6 +243,11 @@ namespace PMDC.Dungeon
         public string ChestAmbushWarningTile;
 
         /// <summary>
+        /// If this is set to true, monster halls will never appear on tiles where you can't see the warning tile
+        /// </summary>
+        public bool NoMonsterHallOnBlockLightTiles;
+        
+        /// <summary>
         /// If this is set to true, you will not be able to spawn into a monster house upon entering a floor.
         /// </summary>
         public bool NoMonsterHouseEntrances;
@@ -251,13 +256,15 @@ namespace PMDC.Dungeon
         {
             MonsterHouseWarningTile = null;
             ChestAmbushWarningTile = null;
+            NoMonsterHallOnBlockLightTiles = false;
             NoMonsterHouseEntrances = false;
         }
 
-        public MonsterHouseTableState(string monsterHouseWarningTile, string chestAmbushWarningTile, bool noMonsterHouseEntrances)
+        public MonsterHouseTableState(string monsterHouseWarningTile, string chestAmbushWarningTile, bool noMonsterHallOnBlockLightTiles, bool noMonsterHouseEntrances)
         {
             MonsterHouseWarningTile = monsterHouseWarningTile; 
             ChestAmbushWarningTile = chestAmbushWarningTile; 
+            NoMonsterHallOnBlockLightTiles = noMonsterHallOnBlockLightTiles;
             NoMonsterHouseEntrances = noMonsterHouseEntrances;
         }
         protected MonsterHouseTableState(MonsterHouseTableState other)
@@ -265,6 +272,7 @@ namespace PMDC.Dungeon
             MonsterHouseWarningTile = other.MonsterHouseWarningTile;
             ChestAmbushWarningTile = other.ChestAmbushWarningTile;
             NoMonsterHouseEntrances = other.NoMonsterHouseEntrances;
+            NoMonsterHallOnBlockLightTiles = other.NoMonsterHallOnBlockLightTiles;
         }
         public override GameplayState Clone() { return new MonsterHouseTableState(this); }
     }

--- a/PMDC/Dungeon/GameEffects/UniversalState.cs
+++ b/PMDC/Dungeon/GameEffects/UniversalState.cs
@@ -227,4 +227,45 @@ namespace PMDC.Dungeon
         }
     }
 
+    [Serializable]
+    public class MonsterHouseTableState : UniversalState
+    {
+        /// <summary>
+        /// If this is set, this tile will be used to display a warning for monster houses.
+        /// </summary>
+        [DataType(0, DataManager.DataType.Tile, false)]
+        public string MonsterHouseWarningTile;
+        
+        /// <summary>
+        /// If this is set, this tile will be used to replace the chest in a chest ambush.
+        /// </summary>
+        [DataType(0, DataManager.DataType.Tile, false)]
+        public string ChestAmbushWarningTile;
+
+        /// <summary>
+        /// If this is set to true, you will not be able to spawn into a monster house upon entering a floor.
+        /// </summary>
+        public bool NoMonsterHouseEntrances;
+
+        public MonsterHouseTableState()
+        {
+            MonsterHouseWarningTile = null;
+            ChestAmbushWarningTile = null;
+            NoMonsterHouseEntrances = false;
+        }
+
+        public MonsterHouseTableState(string monsterHouseWarningTile, string chestAmbushWarningTile, bool noMonsterHouseEntrances)
+        {
+            MonsterHouseWarningTile = monsterHouseWarningTile; 
+            ChestAmbushWarningTile = chestAmbushWarningTile; 
+            NoMonsterHouseEntrances = noMonsterHouseEntrances;
+        }
+        protected MonsterHouseTableState(MonsterHouseTableState other)
+        {
+            MonsterHouseWarningTile = other.MonsterHouseWarningTile;
+            ChestAmbushWarningTile = other.ChestAmbushWarningTile;
+            NoMonsterHouseEntrances = other.NoMonsterHouseEntrances;
+        }
+        public override GameplayState Clone() { return new MonsterHouseTableState(this); }
+    }
 }

--- a/PMDC/LevelGen/Floors/GenSteps/ChestStep.cs
+++ b/PMDC/LevelGen/Floors/GenSteps/ChestStep.cs
@@ -114,9 +114,15 @@ namespace PMDC.LevelGen
 
             int randIndex = map.Rand.Next(freeTiles.Count);
             Loc loc = freeTiles[randIndex];
-
-
+            
             EffectTile spawnedChest = new EffectTile("chest_full", true);
+            
+            if (Ambush && DiagManager.Instance.CurSettings.VisibleMonsterHouses)
+            {
+                //Mark ambush chests if visible monster houses are set
+                spawnedChest = new EffectTile("chest_house_full", true);
+            }
+            
             spawnedChest.TileStates.Set(new UnlockState("key"));
 
             if (Ambush && MobThemes.CanPick)
@@ -129,7 +135,6 @@ namespace PMDC.LevelGen
                 //the mobs in this class are the ones that would be available when the game wants to spawn things outside of the floor's spawn list
                 //it will be queried for monsters that match the theme provided
                 List<MobSpawn> chosenMobs = chosenMobTheme.GenerateMobs(map, Mobs);
-
 
                 MobSpawnState mobSpawn = new MobSpawnState();
                 foreach (MobSpawn mob in chosenMobs)

--- a/PMDC/LevelGen/Floors/GenSteps/ChestStep.cs
+++ b/PMDC/LevelGen/Floors/GenSteps/ChestStep.cs
@@ -117,10 +117,10 @@ namespace PMDC.LevelGen
             
             EffectTile spawnedChest = new EffectTile("chest_full", true);
             
-            if (Ambush && DiagManager.Instance.CurSettings.VisibleMonsterHouses)
+            if (Ambush && GameManager.Instance.ChestAmbushWarningTile != null)
             {
                 //Mark ambush chests if visible monster houses are set
-                spawnedChest = new EffectTile("chest_house_full", true);
+                spawnedChest = new EffectTile(GameManager.Instance.ChestAmbushWarningTile, true);
             }
             
             spawnedChest.TileStates.Set(new UnlockState("key"));

--- a/PMDC/LevelGen/Floors/GenSteps/ChestStep.cs
+++ b/PMDC/LevelGen/Floors/GenSteps/ChestStep.cs
@@ -4,6 +4,7 @@ using RogueElements;
 using RogueEssence.Dungeon;
 using PMDC.Dungeon;
 using RogueEssence;
+using RogueEssence.Data;
 using RogueEssence.LevelGen;
 
 namespace PMDC.LevelGen
@@ -116,11 +117,12 @@ namespace PMDC.LevelGen
             Loc loc = freeTiles[randIndex];
             
             EffectTile spawnedChest = new EffectTile("chest_full", true);
-            
-            if (Ambush && GameManager.Instance.ChestAmbushWarningTile != null)
+
+            MonsterHouseTableState mhtable = DataManager.Instance.UniversalEvent.UniversalStates.GetWithDefault<MonsterHouseTableState>();
+            if (mhtable != null && mhtable.ChestAmbushWarningTile != null && Ambush)
             {
                 //Mark ambush chests if visible monster houses are set
-                spawnedChest = new EffectTile(GameManager.Instance.ChestAmbushWarningTile, true);
+                spawnedChest = new EffectTile(mhtable.ChestAmbushWarningTile, true);
             }
             
             spawnedChest.TileStates.Set(new UnlockState("key"));

--- a/PMDC/LevelGen/Floors/GenSteps/MonsterHallStep.cs
+++ b/PMDC/LevelGen/Floors/GenSteps/MonsterHallStep.cs
@@ -70,7 +70,7 @@ namespace PMDC.LevelGen
                 return;
             
             //Monster halls will never spawn right where you start if no monster house entrances is set
-            if (DiagManager.Instance.CurSettings.NoMonsterHouseEntrances)
+            if (GameManager.Instance.NoMonsterHouseEntrances)
             {
                 bool skipRoom = false;
                 foreach (MapGenEntrance entrance in map.GenEntrances)
@@ -323,10 +323,10 @@ namespace PMDC.LevelGen
                 }
 
                 //Make monster houses visible if set
-                if (DiagManager.Instance.CurSettings.VisibleMonsterHouses)
+                if (GameManager.Instance.MonsterHouseWarningTile != null)
                 {
                     if (map.RoomTerrain.TileEquivalent(map.GetTile(startLoc)))
-                    ((IPlaceableGenContext<EffectTile>)map).PlaceItem(startLoc,  new EffectTile("tile_warning", true));
+                    ((IPlaceableGenContext<EffectTile>)map).PlaceItem(startLoc,  new EffectTile(GameManager.Instance.MonsterHouseWarningTile, true));
                 }
 
                 MonsterHallMapEvent house = new MonsterHallMapEvent();

--- a/PMDC/LevelGen/Floors/GenSteps/MonsterHallStep.cs
+++ b/PMDC/LevelGen/Floors/GenSteps/MonsterHallStep.cs
@@ -87,6 +87,15 @@ namespace PMDC.LevelGen
                 if (skipRoom)
                     return;
             }
+            
+            //Prevents monster halls on tiles such as foliage that block light
+            if (mhtable != null && mhtable.NoMonsterHallOnBlockLightTiles)
+            {
+                if (map.Map.GetTile(originPoint) != null && map.Map.GetTile(originPoint).Data.GetData() != null && map.Map.GetTile(originPoint).Data.GetData().BlockLight)
+                {
+                    return;
+                }
+            }
 
             int stages = 4;
             Loc size = new Loc(Math.Max(Size.X, 1 + stages * 2), Math.Max(Size.Y, 1 + stages * 2));

--- a/PMDC/LevelGen/Floors/GenSteps/MonsterHallStep.cs
+++ b/PMDC/LevelGen/Floors/GenSteps/MonsterHallStep.cs
@@ -70,7 +70,9 @@ namespace PMDC.LevelGen
                 return;
             
             //Monster halls will never spawn right where you start if no monster house entrances is set
-            if (GameManager.Instance.NoMonsterHouseEntrances)
+            MonsterHouseTableState mhtable = DataManager.Instance.UniversalEvent.UniversalStates.GetWithDefault<MonsterHouseTableState>();
+
+            if (mhtable != null && mhtable.NoMonsterHouseEntrances)
             {
                 bool skipRoom = false;
                 foreach (MapGenEntrance entrance in map.GenEntrances)
@@ -323,10 +325,12 @@ namespace PMDC.LevelGen
                 }
 
                 //Make monster houses visible if set
-                if (GameManager.Instance.MonsterHouseWarningTile != null)
+                MonsterHouseTableState mhtable = DataManager.Instance.UniversalEvent.UniversalStates.GetWithDefault<MonsterHouseTableState>();
+
+                if (mhtable != null && mhtable.MonsterHouseWarningTile != null)
                 {
                     if (map.RoomTerrain.TileEquivalent(map.GetTile(startLoc)))
-                    ((IPlaceableGenContext<EffectTile>)map).PlaceItem(startLoc,  new EffectTile(GameManager.Instance.MonsterHouseWarningTile, true));
+                    ((IPlaceableGenContext<EffectTile>)map).PlaceItem(startLoc,  new EffectTile(mhtable.MonsterHouseWarningTile, true));
                 }
 
                 MonsterHallMapEvent house = new MonsterHallMapEvent();

--- a/PMDC/LevelGen/Floors/GenSteps/MonsterHallStep.cs
+++ b/PMDC/LevelGen/Floors/GenSteps/MonsterHallStep.cs
@@ -68,6 +68,23 @@ namespace PMDC.LevelGen
 
             if (!chokePoint)
                 return;
+            
+            //Monster halls will never spawn right where you start if no monster house entrances is set
+            if (DiagManager.Instance.CurSettings.NoMonsterHouseEntrances)
+            {
+                bool skipRoom = false;
+                foreach (MapGenEntrance entrance in map.GenEntrances)
+                {
+                    if (originPoint.Equals(entrance.Loc))
+                    {
+                        skipRoom = true;
+                        break;
+                    }
+                }
+
+                if (skipRoom)
+                    return;
+            }
 
             int stages = 4;
             Loc size = new Loc(Math.Max(Size.X, 1 + stages * 2), Math.Max(Size.Y, 1 + stages * 2));
@@ -305,6 +322,12 @@ namespace PMDC.LevelGen
                     }
                 }
 
+                //Make monster houses visible if set
+                if (DiagManager.Instance.CurSettings.VisibleMonsterHouses)
+                {
+                    if (map.RoomTerrain.TileEquivalent(map.GetTile(startLoc)))
+                    ((IPlaceableGenContext<EffectTile>)map).PlaceItem(startLoc,  new EffectTile("tile_warning", true));
+                }
 
                 MonsterHallMapEvent house = new MonsterHallMapEvent();
                 house.Phases.AddRange(housePhases);

--- a/PMDC/LevelGen/Floors/GenSteps/MonsterHouseStep.cs
+++ b/PMDC/LevelGen/Floors/GenSteps/MonsterHouseStep.cs
@@ -47,7 +47,7 @@ namespace PMDC.LevelGen
             for(int ii = 0; ii < map.RoomPlan.RoomCount; ii++)
             {
                 //Monster houses will never spawn in the starting room if no monster house entrances is set
-                if (DiagManager.Instance.CurSettings.NoMonsterHouseEntrances)
+                if (GameManager.Instance.NoMonsterHouseEntrances)
                 {
                     Rect curRoom = map.RoomPlan.GetRoom(ii).Draw;
                     bool skipRoom = false;
@@ -163,7 +163,7 @@ namespace PMDC.LevelGen
                 MonsterHouseMapEvent house = new MonsterHouseMapEvent();
                 house.Bounds = room.Draw;
 
-                if (DiagManager.Instance.CurSettings.VisibleMonsterHouses)
+                if (GameManager.Instance.MonsterHouseWarningTile != null)
                 {
                     //Make monster houses visible if set
                     for (int xx = house.Bounds.X; xx < house.Bounds.X + house.Bounds.Size.X; xx++)
@@ -172,7 +172,7 @@ namespace PMDC.LevelGen
                         {
                             Loc loc = new Loc(xx, yy);
                             if (map.RoomTerrain.TileEquivalent(map.GetTile(loc)))
-                                ((IPlaceableGenContext<EffectTile>)map).PlaceItem(loc,  new EffectTile("tile_warning", true));
+                                ((IPlaceableGenContext<EffectTile>)map).PlaceItem(loc,  new EffectTile(GameManager.Instance.MonsterHouseWarningTile, true));
                         }
                     }
                 }

--- a/PMDC/LevelGen/Floors/GenSteps/MonsterHouseStep.cs
+++ b/PMDC/LevelGen/Floors/GenSteps/MonsterHouseStep.cs
@@ -47,7 +47,9 @@ namespace PMDC.LevelGen
             for(int ii = 0; ii < map.RoomPlan.RoomCount; ii++)
             {
                 //Monster houses will never spawn in the starting room if no monster house entrances is set
-                if (GameManager.Instance.NoMonsterHouseEntrances)
+                MonsterHouseTableState mhtable = DataManager.Instance.UniversalEvent.UniversalStates.GetWithDefault<MonsterHouseTableState>();
+
+                if (mhtable != null && mhtable.NoMonsterHouseEntrances)
                 {
                     Rect curRoom = map.RoomPlan.GetRoom(ii).Draw;
                     bool skipRoom = false;
@@ -162,8 +164,9 @@ namespace PMDC.LevelGen
             {
                 MonsterHouseMapEvent house = new MonsterHouseMapEvent();
                 house.Bounds = room.Draw;
-
-                if (GameManager.Instance.MonsterHouseWarningTile != null)
+                
+                MonsterHouseTableState mhtable = DataManager.Instance.UniversalEvent.UniversalStates.GetWithDefault<MonsterHouseTableState>();
+                if (mhtable != null && mhtable.MonsterHouseWarningTile != null)
                 {
                     //Make monster houses visible if set
                     for (int xx = house.Bounds.X; xx < house.Bounds.X + house.Bounds.Size.X; xx++)
@@ -172,7 +175,7 @@ namespace PMDC.LevelGen
                         {
                             Loc loc = new Loc(xx, yy);
                             if (map.RoomTerrain.TileEquivalent(map.GetTile(loc)))
-                                ((IPlaceableGenContext<EffectTile>)map).PlaceItem(loc,  new EffectTile(GameManager.Instance.MonsterHouseWarningTile, true));
+                                ((IPlaceableGenContext<EffectTile>)map).PlaceItem(loc,  new EffectTile(mhtable.MonsterHouseWarningTile, true));
                         }
                     }
                 }


### PR DESCRIPTION
Adds two new Settings for the faint of heart:
-Visible Houses, when set to yes, causes monster house and monster hall triggers to be marked with a warning tile, as well as chest ambushes to be marked with a red (instead of a green chest)
-No House Entrances, when set to yes, causes monster house and monster hall triggers to never spawn in any entrance.