### PR TITLE
adjust poison walk event

### DIFF
--- a/PMDC/Dungeon/GameEffects/SingleCharEvent.cs
+++ b/PMDC/Dungeon/GameEffects/SingleCharEvent.cs
@@ -1950,12 +1950,27 @@ namespace PMDC.Dungeon
     [Serializable]
     public class WalkedThisTurnEvent : SingleCharEvent
     {
-        public override GameEvent Clone() { return new WalkedThisTurnEvent(); }
+        public bool AffectNonFocused;
+
+        public WalkedThisTurnEvent() { }
+        public WalkedThisTurnEvent(bool affectNonFocused)
+        {
+            AffectNonFocused = affectNonFocused;
+        }
+        protected WalkedThisTurnEvent(WalkedThisTurnEvent other)
+        {
+            AffectNonFocused = other.AffectNonFocused;
+        }
+        public override GameEvent Clone() { return new WalkedThisTurnEvent(this); }
 
         public override IEnumerator<YieldInstruction> Apply(GameEventOwner owner, Character ownerChar, SingleCharContext context)
         {
-            WalkedThisTurnState recent = ((StatusEffect)owner).StatusStates.GetWithDefault<WalkedThisTurnState>();
-            recent.Walked = true;
+            if (AffectNonFocused || DungeonScene.Instance.CurrentCharacter == context.User)
+            {
+                WalkedThisTurnState recent = ((StatusEffect)owner).StatusStates.GetWithDefault<WalkedThisTurnState>();
+                recent.Walked = true;
+            }
+
             yield break;
         }
     }
@@ -1964,21 +1979,24 @@ namespace PMDC.Dungeon
     public class PoisonSingleEvent : SingleCharEvent
     {
         public bool Toxic;
+        public bool AffectNonFocused;
 
         public PoisonSingleEvent() { }
-        public PoisonSingleEvent(bool toxic)
+        public PoisonSingleEvent(bool toxic, bool affectNonFocused)
         {
             Toxic = toxic;
+            AffectNonFocused = affectNonFocused;
         }
         protected PoisonSingleEvent(PoisonSingleEvent other)
         {
             Toxic = other.Toxic;
+            AffectNonFocused = other.AffectNonFocused;
         }
         public override GameEvent Clone() { return new PoisonSingleEvent(this); }
 
         public override IEnumerator<YieldInstruction> Apply(GameEventOwner owner, Character ownerChar, SingleCharContext context)
         {
-            if (!context.User.CharStates.Contains<MagicGuardState>())
+            if (!context.User.CharStates.Contains<MagicGuardState>() && AffectNonFocused || DungeonScene.Instance.CurrentCharacter == context.User)
             {
                 CountState countState = ((StatusEffect)owner).StatusStates.Get<CountState>();
                 if (Toxic && countState.Count < 16)


### PR DESCRIPTION
Adds the AffectNonFocused attribute to WalkedThisTurnEvent and PoisonSingleEvent, which checks if it's the player's turn if it moves. 

This resolves this [issue](https://github.com/audinowho/PMDODump/issues/277).