### PR TITLE
TeamMemberSpawn simple editor

### DIFF
--- a/PMDC/Data/MonsterFormData.cs
+++ b/PMDC/Data/MonsterFormData.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using RogueElements;
 using System.Drawing;
+using System.Linq;
 using RogueEssence;
 using RogueEssence.Data;
 using RogueEssence.Dungeon;
@@ -264,6 +265,17 @@ namespace PMDC.Data
                 abilities.Add(2);
 
             return abilities;
+        }
+        
+        // TODO: Consider moves from prior evolutions
+        public List<string> GetPossibleSkills()
+        {
+            List<string> skills = new List<string>();
+            skills.AddRange(LevelSkills.Select(x => x.Skill));
+            skills.AddRange(TeachSkills.Select(x => x.Skill));
+            skills.AddRange(SharedSkills.Select(x => x.Skill));
+            skills.AddRange(SecretSkills.Select(x => x.Skill));
+            return skills.Distinct().ToList();
         }
 
 

--- a/PMDC/Dev/Editors/TeamMemberSpawnSimpleEditor.cs
+++ b/PMDC/Dev/Editors/TeamMemberSpawnSimpleEditor.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Reflection;
+using Avalonia.Controls;
+using PMDC.Dev.ViewModels;
+using PMDC.Dev.Views;
+using RogueEssence.Dev;
+using RogueEssence.LevelGen;
+
+namespace PMDC.Dev
+{
+    public class TeamMemberSpawnSimpleEditor : Editor<TeamMemberSpawn>
+    {
+        public override bool SimpleEditor => true;
+        public override string GetString(TeamMemberSpawn obj, Type type, object[] attributes)
+        {
+            MemberInfo[] spawnInfo = type.GetMember(nameof(obj.Spawn));
+            return DataEditor.GetString(obj.Spawn, spawnInfo[0].GetMemberInfoType(), spawnInfo[0].GetCustomAttributes(false));
+        }
+
+        public override void LoadWindowControls(StackPanel control, string parent, Type parentType, string name, Type type, object[] attributes,
+            TeamMemberSpawn obj, Type[] subGroupStack)
+        {
+            TeamMemberSpawnView view = new TeamMemberSpawnView();
+            if (obj.Spawn != null)
+            {
+                view.DataContext = new TeamMemberSpawnModel(new TeamMemberSpawn(obj));
+            }
+            else
+            { 
+                view.DataContext = new TeamMemberSpawnModel();
+            }
+            
+            control.Children.Add(view);
+        }
+        
+        
+        public override TeamMemberSpawn SaveWindowControls(StackPanel control, string name, Type type, object[] attributes, Type[] subGroupStack)
+        {
+            int controlIndex = 0;
+            TeamMemberSpawnView view = (TeamMemberSpawnView)control.Children[controlIndex];
+            TeamMemberSpawnModel mv = (TeamMemberSpawnModel)view.DataContext;
+            return mv.TeamSpawn;
+        }
+        
+    }
+}

--- a/PMDC/Dev/ViewModels/TeamMemberSpawn/BaseMonsterFormViewModel.cs
+++ b/PMDC/Dev/ViewModels/TeamMemberSpawn/BaseMonsterFormViewModel.cs
@@ -1,0 +1,128 @@
+using System;
+using PMDC.Data;
+using RogueEssence.Data;
+using RogueEssence.Dev.ViewModels;
+
+namespace PMDC.Dev.ViewModels
+{
+    public class BaseMonsterFormViewModel : ViewModelBase
+    {
+        private MonsterFormData monsterForm;
+
+        public int Index { get; }
+
+        public BaseMonsterFormViewModel(string key, int formId, int index)
+        {
+            MonsterData data = DataManager.Instance.GetMonster(key);
+            monsterForm = (MonsterFormData) data.Forms[formId];
+            
+            this.key = key;
+            this.formId = formId;
+            Index = index;
+        }
+        
+        public string Name
+        {
+            get { return monsterForm.FormName.ToLocal();  }
+        }
+
+        private string key;
+        public string Key
+        {
+            get { return key; }
+        }
+        
+        private int formId;
+        public int FormId
+        {
+            get { return formId; }
+        }
+        
+        
+        public string Element1Display
+        {
+            get { return DataManager.Instance.GetElement(monsterForm.Element1).Name.ToLocal(); }
+        }
+        
+        public string Element2Display
+        {
+            get { return DataManager.Instance.GetElement(monsterForm.Element2).Name.ToLocal(); }
+        }
+        
+        public string Element1
+        {
+            get { return monsterForm.Element1; }
+        }
+        
+        public string Element2
+        {
+            get { return monsterForm.Element2;  }
+        }
+        
+        public string Intrinsic1
+        {
+            get { return DataManager.Instance.GetIntrinsic(monsterForm.Intrinsic1).Name.ToLocal(); }
+        }
+        
+        public string Intrinsic2
+        {
+            get
+            {
+                return DataManager.Instance.GetIntrinsic(monsterForm.Intrinsic2).Name.ToLocal();
+            }
+        }
+        public string Intrinsic3
+        {
+            get { return DataManager.Instance.GetIntrinsic(monsterForm.Intrinsic3).Name.ToLocal(); }
+        }
+        
+        public bool Temporary
+        {
+            get { return monsterForm.Temporary; }
+        }
+        
+        public bool Released
+        {
+            get { return monsterForm.Released; }
+        }
+        
+        public int BaseHP
+        {
+            get { return monsterForm.BaseHP; }
+        }
+        
+        public int BaseAtk
+        {
+            get { return monsterForm.BaseAtk; }
+        }
+        
+        public int BaseDef
+        {
+            get { return monsterForm.BaseDef; }
+        }
+        
+        public int BaseMAtk
+        {
+            get { return monsterForm.BaseMAtk; }
+        }
+        
+        public int BaseMDef
+        {
+            get { return monsterForm.BaseMDef; }
+        }
+        
+        public int BaseSpeed
+        {
+            get { return monsterForm.BaseSpeed; }
+        }
+        
+        public int BaseTotal
+        {
+            get
+            { 
+                return monsterForm.BaseHP + monsterForm.BaseAtk + monsterForm.BaseDef +
+                     monsterForm.BaseMAtk +  monsterForm.BaseMDef +  monsterForm.BaseSpeed;
+            }
+        }
+    }
+}

--- a/PMDC/Dev/ViewModels/TeamMemberSpawn/IntrinsicViewModel.cs
+++ b/PMDC/Dev/ViewModels/TeamMemberSpawn/IntrinsicViewModel.cs
@@ -1,0 +1,43 @@
+using RogueEssence.Data;
+using RogueEssence.Dev.ViewModels;
+
+namespace PMDC.Dev.ViewModels
+{
+    public class IntrinsicViewModel : ViewModelBase
+    {
+        private IntrinsicData intrinsicData;
+        private bool _monsterLearns;
+
+        public int Index { get; }
+
+        public IntrinsicViewModel(string key, int index)
+        {
+            intrinsicData = DataManager.Instance.GetIntrinsic(key);
+            Index = index;
+        }
+        
+        public bool MonsterLearns
+        {
+            get => _monsterLearns;
+        }
+        
+        public void SetMonsterLearns(bool learns)
+        {
+            _monsterLearns = learns;
+        }
+
+        public string Name
+        {
+            get { return intrinsicData.Name.ToLocal(); }
+        }
+        public bool Released
+        {
+            get { return intrinsicData.Released; }
+        }
+      
+        public string Description
+        {
+            get { return intrinsicData.Desc.ToLocal(); }
+        }
+    }
+}

--- a/PMDC/Dev/ViewModels/TeamMemberSpawn/SkillDataViewModel.cs
+++ b/PMDC/Dev/ViewModels/TeamMemberSpawn/SkillDataViewModel.cs
@@ -1,0 +1,91 @@
+using RogueEssence;
+using RogueEssence.Data;
+using RogueEssence.Dev.ViewModels;
+using RogueEssence.Dungeon;
+
+namespace PMDC.Dev.ViewModels
+{
+    public class SkillDataViewModel : ViewModelBase
+    {
+        private SkillData skillData;
+        private BasePowerState powerState;
+        public int Index { get; }
+        private bool _monsterLearns;
+        
+
+        public SkillDataViewModel(string skillKey, int index)
+        {
+            Index = index;
+            skillData = DataManager.Instance.GetSkill(skillKey);
+            ElementDisplay = DataManager.Instance.GetElement(skillData.Data.Element).Name.ToLocal();
+            powerState = skillData.Data.SkillStates.GetWithDefault<BasePowerState>();
+        }
+
+
+        public void SetMonsterLearns(bool learns)
+        {
+            _monsterLearns = learns;
+        }
+        
+        
+        public bool MonsterLearns
+        {
+            get { return _monsterLearns; }
+        }
+        
+        public string Name
+        {
+            get { return skillData.Name.ToLocal();  }
+        }
+        
+        public string Element
+        {
+            get { return skillData.Data.Element;  }
+        }
+        
+        public string ElementDisplay
+        {
+            get;
+        }
+        
+        public BattleData.SkillCategory Category
+        {
+            get { return skillData.Data.Category; }
+        }
+        public string CategoryDisplay
+        {
+            get { return skillData.Data.Category.ToLocal();  }
+        }
+        
+        public int BasePower
+        {
+            get { return powerState != null ? powerState.Power : -1; }
+        }
+        
+        public int BaseCharges
+        {
+            get { return skillData.BaseCharges; }
+        }
+
+        
+        public int Accuracy
+        {
+            get { return skillData.Data.HitRate; }
+        }
+
+        public string RangeDescription
+        {
+            get { return skillData.HitboxAction.GetDescription(); }
+        }
+        
+        public string Description
+        {
+            get { return skillData.Desc.ToLocal(); }
+        }
+
+        public bool Released
+        {
+            get { return skillData.Released; }
+        }
+    }
+}

--- a/PMDC/Dev/ViewModels/TeamMemberSpawn/SkillDataViewModel.cs
+++ b/PMDC/Dev/ViewModels/TeamMemberSpawn/SkillDataViewModel.cs
@@ -7,8 +7,7 @@ namespace PMDC.Dev.ViewModels
 {
     public class SkillDataViewModel : ViewModelBase
     {
-        private SkillData skillData;
-        private BasePowerState powerState;
+        private SkillDataSummary summary;
         public int Index { get; }
         private bool _monsterLearns;
         
@@ -16,9 +15,7 @@ namespace PMDC.Dev.ViewModels
         public SkillDataViewModel(string skillKey, int index)
         {
             Index = index;
-            skillData = DataManager.Instance.GetSkill(skillKey);
-            ElementDisplay = DataManager.Instance.GetElement(skillData.Data.Element).Name.ToLocal();
-            powerState = skillData.Data.SkillStates.GetWithDefault<BasePowerState>();
+            summary = (SkillDataSummary) DataManager.Instance.DataIndices[DataManager.DataType.Skill].Get(skillKey);
         }
 
 
@@ -35,57 +32,56 @@ namespace PMDC.Dev.ViewModels
         
         public string Name
         {
-            get { return skillData.Name.ToLocal();  }
+            get { return summary.Name.ToLocal();  }
         }
         
         public string Element
         {
-            get { return skillData.Data.Element;  }
+            get { return summary.Element;  }
         }
         
         public string ElementDisplay
         {
-            get;
+            get { return DataManager.Instance.GetElement(Element).Name.ToLocal(); }
         }
         
         public BattleData.SkillCategory Category
         {
-            get { return skillData.Data.Category; }
+            get { return summary.Category; }
         }
         public string CategoryDisplay
         {
-            get { return skillData.Data.Category.ToLocal();  }
+            get { return summary.Category.ToLocal();  }
         }
         
         public int BasePower
         {
-            get { return powerState != null ? powerState.Power : -1; }
+            get { return summary.BasePower; }
         }
         
         public int BaseCharges
         {
-            get { return skillData.BaseCharges; }
+            get { return summary.BaseCharges; }
         }
-
         
         public int Accuracy
         {
-            get { return skillData.Data.HitRate; }
+            get { return summary.Accuracy; }
         }
 
         public string RangeDescription
         {
-            get { return skillData.HitboxAction.GetDescription(); }
+            get { return summary.RangeDescription; }
         }
         
         public string Description
         {
-            get { return skillData.Desc.ToLocal(); }
+            get { return summary.Description.ToLocal(); }
         }
 
         public bool Released
         {
-            get { return skillData.Released; }
+            get { return summary.Released; }
         }
     }
 }

--- a/PMDC/Dev/ViewModels/TeamMemberSpawn/SkillDataViewModel.cs
+++ b/PMDC/Dev/ViewModels/TeamMemberSpawn/SkillDataViewModel.cs
@@ -66,7 +66,7 @@ namespace PMDC.Dev.ViewModels
         
         public int Accuracy
         {
-            get { return summary.Accuracy; }
+            get { return summary.HitRate; }
         }
 
         public string RangeDescription

--- a/PMDC/Dev/ViewModels/TeamMemberSpawn/TeamMemberSpawnModel.cs
+++ b/PMDC/Dev/ViewModels/TeamMemberSpawn/TeamMemberSpawnModel.cs
@@ -1039,18 +1039,22 @@ namespace PMDC.Dev.ViewModels
 
         public void UpdateDataGrid()
         {
-            DataGridType nextView = DataGridType.Monster;
+            DataGridType nextView = CurrentDataGridView;
             if (FocusIndex >= 6)
             {
-                nextView = DataGridType.Other;
+                // nextView = DataGridType.Other;
             }
-            else if (FocusIndex >= 5)
+            else if (FocusIndex == 5)
             {
                 nextView = DataGridType.Intrinsic;
             }
             else if (FocusIndex >= 1)
             {
                 nextView = DataGridType.Skills;
+            }
+            else if (FocusIndex == 0)
+            {
+                nextView = DataGridType.Monster;
             }
 
             CurrentDataGridView = nextView;

--- a/PMDC/Dev/ViewModels/TeamMemberSpawn/TeamMemberSpawnModel.cs
+++ b/PMDC/Dev/ViewModels/TeamMemberSpawn/TeamMemberSpawnModel.cs
@@ -1,0 +1,1069 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Text.RegularExpressions;
+using PMDC.Data;
+using PMDC.LevelGen;
+using ReactiveUI;
+using RogueEssence;
+using RogueEssence.Data;
+using RogueEssence.Dev;
+using RogueEssence.Dev.ViewModels;
+using RogueEssence.Dev.Views;
+using RogueEssence.Dungeon;
+using RogueEssence.LevelGen;
+
+namespace PMDC.Dev.ViewModels
+{ 
+    public class TeamMemberSpawnModel : ViewModelBase
+    {
+        public TeamMemberSpawn TeamSpawn;
+        public CollectionBoxViewModel SpawnConditions { get; set; }
+        public CollectionBoxViewModel SpawnFeatures { get; set; }
+
+        private bool _applySearch = true;
+        private bool _checkSpawnFeatureDiff = true;
+        
+        private int _selectedMonsterIndex;
+        public int SelectedMonsterIndex
+        {
+            get { return _selectedMonsterIndex; }
+            set
+            {
+               
+                if (this.SetIfChanged(ref _selectedMonsterIndex, value))
+                {
+                    UpdateMonster(_selectedMonsterIndex);
+                }
+            }
+        }
+        
+        
+        private bool _disableUnusedSlots;
+
+        public bool DisableUnusedSlots
+        {
+            get { return _disableUnusedSlots; }
+            set
+            {
+                if (this.SetIfChanged(ref _disableUnusedSlots, value)  && _checkSpawnFeatureDiff)
+                {
+                    ToggleUnusedSlots(_disableUnusedSlots);
+                }
+            }
+        }
+        
+        
+        private bool _isWeakMonster;
+
+        public bool IsWeakMob
+        {
+            get { return _isWeakMonster; }
+            set
+            {
+                if (this.SetIfChanged(ref _isWeakMonster, value)  && _checkSpawnFeatureDiff)
+                {
+                    ToggleWeakMonster(_isWeakMonster);
+                }
+            }
+        }
+        
+        private bool _unrecruitable;
+        public bool Unrecruitable
+        {
+            get { return _unrecruitable; }
+            set
+            {
+                if (this.SetIfChanged(ref _unrecruitable, value)  && _checkSpawnFeatureDiff)
+                {
+                    ToggleUnrecruitable(_unrecruitable);
+                }
+            }
+        }
+        
+
+        private void ToggleUnusedSlots(bool disable)
+        {
+            List<MobSpawnExtra> features = SpawnFeatures.GetList<List<MobSpawnExtra>>();
+            if (disable)
+            {
+                int skillCount = getSkillList().Count;
+                SpawnFeatures.InsertItem(SpawnFeatures.Collection.Count, new MobSpawnMovesOff(skillCount));
+            }
+            else
+            {
+                for (int ii = features.Count - 1; ii >= 0; ii--)
+                {
+                    if (features[ii] is MobSpawnMovesOff)
+                    {
+                        SpawnFeatures.DeleteItem(ii);
+                    }
+                }
+            }
+        }
+        
+        private void ToggleWeakMonster(bool weak)
+        {
+            List<MobSpawnExtra> features = SpawnFeatures.GetList<List<MobSpawnExtra>>();
+            if (weak)
+            {
+                SpawnFeatures.InsertItem(SpawnFeatures.Collection.Count, new MobSpawnWeak());
+            }
+            else
+            {
+                for (int ii = features.Count - 1; ii >= 0; ii--)
+                {
+                    if (features[ii] is MobSpawnWeak)
+                    {
+                        SpawnFeatures.DeleteItem(ii);
+                    }
+                }
+            }
+        }
+        
+        private void ToggleUnrecruitable(bool unrecruitable)
+        {
+
+            List<MobSpawnExtra> features = SpawnFeatures.GetList<List<MobSpawnExtra>>();
+            for (int ii = features.Count - 1; ii >= 0; ii--)
+            {
+                if (features[ii] is MobSpawnUnrecruitable)
+                {
+                    SpawnFeatures.DeleteItem(ii);
+                }
+            }
+            
+            if (unrecruitable)
+            {
+                SpawnFeatures.InsertItem(SpawnFeatures.Collection.Count, new MobSpawnUnrecruitable());
+            }
+        }
+        
+        private int _selectedIntrinsicIndex;
+
+        public int SelectedIntrinsicIndex
+        {
+            get { return _selectedIntrinsicIndex; }
+            set
+            {
+                if (this.SetIfChanged(ref _selectedIntrinsicIndex, value))
+                {
+                    UpdateIntrinsic(_selectedIntrinsicIndex);
+                }
+            }
+        }
+
+        private void UpdateIntrinsic(int index)
+        {
+            string intrinsic = "";
+            if (_selectedIntrinsicIndex != -1)
+            {
+                intrinsic = intrinsicKeys[index];
+                SelectedIntrinsic = intrinsicData[index];
+            } 
+
+            TeamSpawn.Spawn.Intrinsic = intrinsic;
+        }
+        
+        private bool _includeUnreleasedIntrinsics;
+        public bool IncludeUnreleasedIntrinsics
+        {
+            get { return _includeUnreleasedIntrinsics; }
+            set
+            {
+                
+                if (this.SetIfChanged(ref _includeUnreleasedIntrinsics, value))
+                {
+                    if (_applySearch) 
+                        updateIntrinsicData(SearchIntrinsicFilter);
+                    
+                }
+            }
+        }
+
+        private bool _includeUnreleasedSkills;
+        public bool IncludeUnreleasedSkills
+        {
+            get { return _includeUnreleasedSkills; }
+            set
+            {
+                
+                if (this.SetIfChanged(ref _includeUnreleasedSkills, value))
+                {
+                    if (_applySearch) 
+                        UpdateSkillData(CurrentSkillSearchFilter);
+                }
+            }
+        }
+        
+        private bool _includeUnreleasedForms;
+        public bool IncludeTemporaryForms
+        {
+            get => _includeTemporaryForms;
+            set
+            {
+                if (this.SetIfChanged(ref _includeTemporaryForms, value))
+                { 
+                    if (_applySearch) 
+                        updateMonsterForms(SearchMonsterFilter);
+                }
+            }
+        }
+        
+        private bool _includeTemporaryForms;
+        public bool IncludeUnreleasedForms
+        {
+            get => _includeUnreleasedForms;
+            set
+            {
+                if (this.SetIfChanged(ref _includeUnreleasedForms, value))
+                {
+                    if (_applySearch) 
+                        updateMonsterForms(SearchMonsterFilter);
+                }
+            }
+        }
+
+
+        private string _searchMonsterFilter;
+        public string SearchMonsterFilter
+        {
+            get => _searchMonsterFilter;
+            set
+            {
+                if (this.SetIfChanged(ref _searchMonsterFilter, value))
+                {
+                    if (_applySearch) 
+                        updateMonsterForms(_searchMonsterFilter);
+                }
+            }
+        }
+        private string _searchIntrinsicFilter = string.Empty;
+        public string SearchIntrinsicFilter
+        {
+            get => _searchIntrinsicFilter;
+            set
+            {
+                if (this.SetIfChanged(ref _searchIntrinsicFilter, value))
+                {
+                    if (_applySearch) 
+                        updateIntrinsicData(_searchIntrinsicFilter);
+                }
+            }
+        }
+        public int Min
+        {
+            get { return TeamSpawn.Spawn.Level.Min; }
+            set { this.RaiseAndSetIfChanged(ref TeamSpawn.Spawn.Level.Min, value); }
+        }
+        
+        public int Max
+        {
+            get { return TeamSpawn.Spawn.Level.Max; }
+            set { this.RaiseAndSetIfChanged(ref TeamSpawn.Spawn.Level.Max, value); }
+        }
+            
+        private DataGridType _gridViewType = DataGridType.Monster; 
+        public DataGridType CurrentDataGridView
+        {
+            get { return _gridViewType; }
+            set { this.RaiseAndSetIfChanged(ref _gridViewType, value); }
+        }
+        
+        public string CurrentSkillSearchFilter;
+            
+        private string _searchSkill0Filter = string.Empty;
+        public string SearchSkill0Filter
+        {
+            get { return _searchSkill0Filter; }
+            set
+            { 
+                if (this.SetIfChanged(ref _searchSkill0Filter, value))
+                {
+                    UpdateSkillData(_searchSkill0Filter);
+                }
+            }
+        }
+        
+         
+        private string _searchSkill1Filter = string.Empty;
+        public string SearchSkill1Filter
+        {
+            get { return _searchSkill1Filter; }
+            set
+            { 
+                if (this.SetIfChanged(ref _searchSkill1Filter, value))
+                {
+                    UpdateSkillData(_searchSkill1Filter);
+                }
+            }
+        }
+        
+        private string _searchSkill2Filter = string.Empty;
+        public string SearchSkill2Filter
+        {
+            get { return _searchSkill2Filter; }
+            set
+            { 
+                if (this.SetIfChanged(ref _searchSkill2Filter, value))
+                {
+                    UpdateSkillData(_searchSkill2Filter);
+                }
+            }
+        }
+        private string _searchSkill3Filter = string.Empty;
+        public string SearchSkill3Filter
+        {
+            get { return _searchSkill3Filter; }
+            set
+            { 
+                if (this.SetIfChanged(ref _searchSkill3Filter, value))
+                {
+                    UpdateSkillData(_searchSkill3Filter);
+                }
+            }
+        }
+
+        private void updateMonsterForms(string filter)
+        {
+            FilteredMonsterForms.Clear();
+            IEnumerable<BaseMonsterFormViewModel> result = monsterForms.Select(item => new
+                {
+                    item,
+                    startsWith = startsWith(item.Name, filter),
+                    prefixStartsWith = prefixStartsWith(item.Name, filter),
+                    includeUnreleased = IncludeUnreleasedForms || item.Released,
+                    temporary = !item.Temporary || IncludeTemporaryForms,
+                })
+                .Where(item =>
+                    {
+                        return (item.prefixStartsWith || item.startsWith) && item.temporary & item.includeUnreleased;
+                    }
+                )
+                .OrderByDescending(item => item.startsWith)
+                .ThenByDescending(item => item.prefixStartsWith)
+                .Select(x => x.item);
+            addFilteredItems<BaseMonsterFormViewModel>(FilteredMonsterForms, result);
+        }
+        private void updateIntrinsicData(string filter)
+        {
+            FilteredIntrinsicData.Clear();
+            IEnumerable<IntrinsicViewModel> result;
+            
+            if (SearchIntrinsicFilter == "")
+            {
+                ResetIntrinsic();
+                result = intrinsicData.Select(item => new
+                    {
+                        item,
+                        learns = item.MonsterLearns,
+                        includeUnreleased = IncludeUnreleasedIntrinsics || item.Released,
+                        selected = item.Index == SelectedIntrinsicIndex,
+                    })
+                    .Where(item =>
+                        {
+                            return (item.learns || item.selected) && item.includeUnreleased;
+                        }
+                    )
+                    .Select(x => x.item);
+            }
+            else
+            {
+
+                result = intrinsicData.Select(item => new
+                    {
+                        item,
+                        startsWith = startsWith(item.Name, filter),
+                        prefixStartsWith = prefixStartsWith(item.Name, filter),
+                        includeUnreleased = IncludeUnreleasedIntrinsics || item.Released,
+                        learns = item.MonsterLearns,
+                    })
+                    .Where(item =>
+                        {
+                            return (item.prefixStartsWith || item.startsWith) && item.includeUnreleased;
+                        }
+                    )
+                    .OrderByDescending(item => item.learns)
+                    .ThenByDescending(item => item.startsWith)
+                    .ThenByDescending(item => item.prefixStartsWith)
+                    .Select(x => x.item);
+            }
+            
+            addFilteredItems<IntrinsicViewModel>(FilteredIntrinsicData, result);
+        }
+        
+        public int FocusedSkillIndex;
+        
+        // TODO: Remove logic from view?
+        public void UpdateSkillData(string filter)
+        {
+            CurrentSkillSearchFilter = filter;
+            FilteredSkillData.Clear();
+            IEnumerable<SkillDataViewModel> result;
+            if (CurrentSkillSearchFilter == "")
+            {
+                ResetSkill();
+                result = skillData.Select(item => new
+                    {
+                        item,
+                        learns = item.MonsterLearns,
+                        includeUnreleased = IncludeUnreleasedSkills || item.Released,
+                        inSkillData = SkillIndex.Contains(item.Index),
+                    })
+                    .Where(item =>
+                        {
+                            return (item.learns || item.inSkillData) && item.includeUnreleased;
+                        }
+                    )
+                    .Select(x => x.item);
+            }
+            else
+            {
+                
+                result = skillData.Select(item => new
+                    {
+                        item,
+                        startsWith = startsWith(item.Name, filter),
+                        prefixStartsWith = prefixStartsWith(item.Name, filter),
+                        includeUnreleased = IncludeUnreleasedSkills || item.Released,
+                        learns = item.MonsterLearns,
+                    })
+                    .Where(item =>
+                        {
+                            return (item.prefixStartsWith || item.startsWith) && item.includeUnreleased;
+                        }
+                    )
+                    .OrderByDescending(item => item.learns)
+                    .ThenByDescending(item => item.startsWith)
+                    .ThenByDescending(item => item.prefixStartsWith)
+                    .Select(x => x.item);
+            }
+
+            addFilteredItems<SkillDataViewModel>(FilteredSkillData, result);
+        }
+        
+        public int ChosenGender
+        {
+            get { return genderKeys.IndexOf((int) TeamSpawn.Spawn.BaseForm.Gender); }
+            set
+            {
+                this.RaiseAndSetIfChanged(ref TeamSpawn.Spawn.BaseForm.Gender, (Gender) genderKeys[value]);
+            }
+        }
+
+        public void SetMonster(int index)
+        {
+            SelectedMonsterIndex = index;
+            BaseMonsterFormViewModel vm = monsterForms[index];
+            SearchMonsterFilter = vm.Name;
+        }
+
+        private void UpdateMonster(int index)
+        {
+            BaseMonsterFormViewModel vm = monsterForms[index];
+            
+            _applySearch = false;
+            SelectedMonsterForm = vm;
+            TeamSpawn.Spawn.BaseForm.Form = vm.FormId;
+            TeamSpawn.Spawn.BaseForm.Species = vm.Key;
+            SetFormPossibleSkills(vm.Key, vm.FormId);
+            SetFormPossibleIntrinsics(vm.Key, vm.FormId);
+            updateIntrinsicData(_searchIntrinsicFilter);
+            SkillIndex = new List<int> { -1, -1, -1, -1 };
+            TeamSpawn.Spawn.SpecifiedSkills = new List<string>();
+            SearchSkill0Filter = "";
+            SearchSkill1Filter = "";
+            SearchSkill2Filter = "";
+            SearchSkill3Filter = "";
+            SearchIntrinsicFilter = "";
+            SelectedIntrinsic = null;
+            SelectedIntrinsicIndex = -1;
+            _applySearch = true;
+            
+        }
+        private BaseMonsterFormViewModel _selectedMonsterForm;
+        public BaseMonsterFormViewModel SelectedMonsterForm
+        {
+            get => _selectedMonsterForm;
+            set
+            {
+                this.RaiseAndSetIfChanged(ref _selectedMonsterForm, value);
+            }
+        }
+        
+        private IntrinsicViewModel _selectedIntrinsic;
+        public IntrinsicViewModel SelectedIntrinsic
+        {
+            get => _selectedIntrinsic;
+            set { this.RaiseAndSetIfChanged(ref _selectedIntrinsic, value); }
+        }
+        
+        
+        private SkillDataViewModel _selectedSkillData;
+        public SkillDataViewModel SelectedSkillData
+        {
+            get => _selectedSkillData;
+            set { this.RaiseAndSetIfChanged(ref _selectedSkillData, value); }
+        }
+        
+        public int ChosenSkin
+        {
+            get { return skinKeys.IndexOf(TeamSpawn.Spawn.BaseForm.Skin); }
+            set { this.RaiseAndSetIfChanged(ref TeamSpawn.Spawn.BaseForm.Skin, skinKeys[value]); }
+        }
+        
+        public int ChosenTactic
+        {
+            get { return tacticKeys.IndexOf(TeamSpawn.Spawn.Tactic); }
+            set { this.RaiseAndSetIfChanged(ref TeamSpawn.Spawn.Tactic, tacticKeys[value]); }
+        }
+        
+        public int ChosenRole
+        {
+            get { return Roles.IndexOf(TeamSpawn.Role.ToLocal()); }
+            set { this.RaiseAndSetIfChanged(ref TeamSpawn.Role,  (TeamMemberSpawn.MemberRole) value); }
+        }
+        
+        private int _focusIndex;
+        public int FocusIndex
+        {
+            get => _focusIndex;
+            set => _focusIndex = value;
+        }
+        
+        public void SetFocusIndex(int index)
+        {
+            FocusIndex = index;
+            UpdateDataGrid();
+        }
+        
+        private List<string> tacticKeys;
+        private List<string> monsterKeys;
+        private List<string> skinKeys;
+        private List<int> genderKeys;
+        private List<string> intrinsicKeys;
+        private List<string> skillKeys;
+        
+        private List<BaseMonsterFormViewModel> monsterForms;
+        private List<SkillDataViewModel> skillData;
+        private List<IntrinsicViewModel> intrinsicData;
+        public List<int> SkillIndex;
+        
+        public ObservableCollection<string> Tactics { get; set; }
+        
+        public ObservableCollection<string> Skins { get; set; }
+        public ObservableCollection<string> Genders { get; set; }
+        public ObservableCollection<string> Roles { get; set;  }
+        public ObservableCollection<BaseMonsterFormViewModel> FilteredMonsterForms { get; set; }
+        public ObservableCollection<SkillDataViewModel> FilteredSkillData { get; set; }
+        public ObservableCollection<IntrinsicViewModel> FilteredIntrinsicData { get; set; }
+        
+        
+        private void InitializeGenders()
+        {
+            Genders = new ObservableCollection<string>();
+            genderKeys = new List<int>();
+
+            for (int ii = -1; ii <= (int)Gender.Female; ii++)
+            {
+                Genders.Add(((Gender)ii).ToLocal());
+                genderKeys.Add(ii);
+            }
+            
+        }
+
+        private void InitializeIntrinsics()
+        {
+            FilteredIntrinsicData = new ObservableCollection<IntrinsicViewModel>();
+            PossibleIntrinsicIndexes = new List<int>();
+            intrinsicData = new List<IntrinsicViewModel>();
+            intrinsicKeys = new List<string>();
+            Dictionary<string, string> intrinsicNames = DataManager.Instance.DataIndices[DataManager.DataType.Intrinsic].GetLocalStringArray(true);
+
+            int ii = 0;
+            foreach (string key in intrinsicNames.Keys)
+            {
+                intrinsicKeys.Add(key);
+                intrinsicData.Add(new IntrinsicViewModel(key, ii));
+                ii++;
+            }
+
+        }
+
+
+        public void ReplaceSkillIndex(int index, int skillIndex = -1)
+        {
+            if (skillIndex != -1)
+            {
+                SkillIndex[skillIndex] = index;
+            }
+            else
+            {
+                SkillIndex[FocusedSkillIndex] = index;
+                
+            }
+            
+            TeamSpawn.Spawn.SpecifiedSkills = getSkillList();
+        }
+        
+        public void SetSkill(SkillDataViewModel skillData, int ind = -1)
+        {
+            ReplaceSkillIndex(skillData.Index, ind);
+
+            int index = ind;
+            
+            if (ind == -1)
+            {
+                index = FocusedSkillIndex;
+            }
+            
+            if (index == 0)
+            {
+                SearchSkill0Filter = skillData.Name;
+            } else if (index == 1)
+            {
+                SearchSkill1Filter = skillData.Name;
+            } else if (index == 2)
+            {
+                SearchSkill2Filter = skillData.Name;
+            } else if (index == 3)
+            {
+                SearchSkill3Filter = skillData.Name;   
+            }
+        }
+        
+        public void SetIntrinsic(IntrinsicViewModel vm)
+        {
+            SelectedIntrinsicIndex = vm.Index;
+            SearchIntrinsicFilter = vm.Name;
+            TeamSpawn.Spawn.Intrinsic = intrinsicKeys[vm.Index];
+        }
+        
+        public void ResetIntrinsic()
+        {
+            SelectedIntrinsicIndex = -1;
+        }
+        
+        public void ResetSkill(int skillSlot = -1)
+        {
+            ReplaceSkillIndex(-1, skillSlot);
+        }
+        
+        // public void ResetMonster()
+        // {
+        //     SelectedMonsterIndex = -1;
+        // }
+        
+        public SkillDataViewModel SkillDataAtIndex(int index)
+        {
+            return skillData[index];
+        }
+        
+        public BaseMonsterFormViewModel MonsterAtIndex(int index)
+        {
+            return monsterForms[index];
+        }
+        
+        public IntrinsicViewModel IntrinsicAtIndex(int index)
+        {
+            return intrinsicData[index];
+        }
+        private void InitializeSkills()
+        {
+            PossibleSkillIndexes = new List<int>();
+            skillData = new List<SkillDataViewModel>();
+            FilteredSkillData = new ObservableCollection<SkillDataViewModel>();
+            skillKeys = new List<string>();
+            Dictionary<string, string> skillNames = DataManager.Instance.DataIndices[DataManager.DataType.Skill].GetLocalStringArray(true);
+            
+            int ii = 0;
+            foreach (string key in skillNames.Keys)
+            {
+                skillKeys.Add(key);
+                skillData.Add(new SkillDataViewModel(key, ii));
+                ii++;
+            }
+            SkillIndex = new List<int> { -1, -1, -1, -1 };
+        }
+
+        private void InitializeMonsters()
+        {
+            monsterKeys = new List<string>();
+            Dictionary<string, string> monsterNames = DataManager.Instance.DataIndices[DataManager.DataType.Monster].GetLocalStringArray(true);
+            List<BaseMonsterFormViewModel> forms = new List<BaseMonsterFormViewModel>();
+
+            int index = 0;
+            foreach (string key in monsterNames.Keys)
+            {
+                monsterKeys.Add(key);
+                MonsterEntrySummary summary = (MonsterEntrySummary)DataManager.Instance.DataIndices[DataManager.DataType.Monster].Get(key);
+               
+                for (int jj = 0; jj < summary.Forms.Count; jj++)
+                {
+              
+                    forms.Add(new BaseMonsterFormViewModel(key, jj, index));
+                    index += 1;
+                }
+            }
+            
+            monsterForms = new List<BaseMonsterFormViewModel>(forms);
+            FilteredMonsterForms = new ObservableCollection<BaseMonsterFormViewModel>();
+        }
+
+        
+        private void InitializeSkins()
+        {
+            Skins = new ObservableCollection<string>();
+            skinKeys = new List<string>();
+            Skins.Add("**EMPTY**");
+            skinKeys.Add("");
+            
+            Dictionary<string, string> skin_names = DataManager.Instance.DataIndices[DataManager.DataType.Skin].GetLocalStringArray(true);
+            foreach (string key in skin_names.Keys)
+            {
+                Skins.Add(skin_names[key]);
+                skinKeys.Add(key);
+            }
+        }
+        
+        private void InitializeTactics()
+        {
+            Tactics = new ObservableCollection<string>();
+            Dictionary<string, string> tacticNames = DataManager.Instance.DataIndices[DataManager.DataType.AI].GetLocalStringArray(true);
+
+            tacticKeys = new List<string>();
+
+            foreach (string key in tacticNames.Keys)
+            {
+                tacticKeys.Add(key);
+                Tactics.Add(tacticNames[key]);
+            }
+
+        }
+
+        private void InitializeRoles()
+        {   
+            Roles = new ObservableCollection<string>();
+            for (int ii = 0; ii <= (int)TeamMemberSpawn.MemberRole.Loner; ii++) {
+                Roles.Add(((TeamMemberSpawn.MemberRole)ii).ToLocal());
+            }
+        }
+        
+     
+
+        public void Initialize()
+        {
+            InitializeMonsters();
+            InitializeGenders();
+            InitializeIntrinsics();
+            InitializeSkills();
+            InitializeSkins();
+            InitializeTactics();
+            InitializeRoles();
+            DevForm devForm = (DevForm)DiagManager.Instance.DevEditor;
+            SpawnConditions = new CollectionBoxViewModel(devForm, new StringConv(typeof(MobSpawnCheck), new object[0]));
+            SpawnConditions.OnMemberChanged += SpawnConditionsChanged;
+            SpawnConditions.OnEditItem += SpawnConditionsEditItem;
+            SpawnConditions.LoadFromList(TeamSpawn.Spawn.SpawnConditions);
+            
+            SpawnFeatures = new CollectionBoxViewModel(devForm, new StringConv(typeof(MobSpawnExtra), new object[0]));
+            SpawnFeatures.OnMemberChanged += SpawnFeaturesChanged;
+            SpawnFeatures.OnEditItem += SpawnFeaturesEditItem;
+            SpawnFeatures.LoadFromList(TeamSpawn.Spawn.SpawnFeatures);
+        }
+
+
+        public List<int> PossibleSkillIndexes;
+        
+        private void SetFormPossibleSkills(string species, int formId)
+        {
+
+            foreach (int index in PossibleSkillIndexes)
+            {
+                skillData[index].SetMonsterLearns(false);
+            }
+            PossibleSkillIndexes.Clear();
+            
+            MonsterData entry = DataManager.Instance.GetMonster(species);
+            MonsterFormData form = (MonsterFormData) entry.Forms[formId];
+            List<string> possibleSkills = form.GetPossibleSkills();
+            foreach (string skill in possibleSkills)
+            {
+                int index = skillKeys.BinarySearch(skill);
+                skillData[index].SetMonsterLearns(true);
+                PossibleSkillIndexes.Add(index);
+            }
+        }
+
+        public List<int> PossibleIntrinsicIndexes;
+        private void SetFormPossibleIntrinsics(string species, int formId)
+        {
+            foreach (int index in PossibleIntrinsicIndexes)
+            {
+                intrinsicData[index].SetMonsterLearns(false);
+            }
+            PossibleIntrinsicIndexes.Clear();
+            
+            MonsterData entry = DataManager.Instance.GetMonster(species);
+            BaseMonsterForm form = entry.Forms[formId];
+
+            List<string> possibleIntrinsics = new List<string>(
+                    new string[] { form.Intrinsic1, form.Intrinsic2, form.Intrinsic3 })
+                .Where(intrinsic => intrinsic != "none")
+                .ToList();
+            foreach (string intrinsic in possibleIntrinsics)
+            {
+                int index = intrinsicKeys.BinarySearch(intrinsic);
+                intrinsicData[index].SetMonsterLearns(true);
+                PossibleIntrinsicIndexes.Add(index);
+
+            }
+        }
+        
+        public void SpawnConditionsChanged()
+        {
+            TeamSpawn.Spawn.SpawnConditions = SpawnConditions.GetList<List<MobSpawnCheck>>();
+        }
+        
+        public void SpawnFeaturesChanged()
+        {
+            TeamSpawn.Spawn.SpawnFeatures = SpawnFeatures.GetList<List<MobSpawnExtra>>();
+            _checkSpawnFeatureDiff = false;
+            
+            // prevent an infinite loop caused by the change 
+            Unrecruitable = containsType<MobSpawnExtra, MobSpawnUnrecruitable>(TeamSpawn.Spawn.SpawnFeatures);
+            DisableUnusedSlots = containsType<MobSpawnExtra, MobSpawnMovesOff>(TeamSpawn.Spawn.SpawnFeatures);
+            IsWeakMob = containsType<MobSpawnExtra, MobSpawnWeak>(TeamSpawn.Spawn.SpawnFeatures);
+            _checkSpawnFeatureDiff = true;
+        }
+
+
+        public void SpawnConditionsEditItem(int index, object element, bool advancedEdit, CollectionBoxViewModel.EditElementOp op)
+        {
+            string elementName = "Spawn Conditions[" + index + "]";
+            DataEditForm frmData = new DataEditRootForm();
+            frmData.Title = DataEditor.GetWindowTitle("Spawn", elementName, element, typeof(MobSpawnCheck), new object[0]);
+
+            DataEditor.LoadClassControls(frmData.ControlPanel, "Spawn", null, elementName, typeof(MobSpawnCheck), new object[0], element, true, new Type[0], advancedEdit);
+            DataEditor.TrackTypeSize(frmData, typeof(MobSpawnCheck));
+            
+            frmData.SelectedOKEvent += async () =>
+            {
+                element = DataEditor.SaveClassControls(frmData.ControlPanel, elementName, typeof(MobSpawnCheck), new object[0], true, new Type[0], advancedEdit);
+                op(index, element);
+                return true;
+            };
+            
+            frmData.Show();
+        }
+        
+        public void SpawnFeaturesEditItem(int index, object element, bool advancedEdit, CollectionBoxViewModel.EditElementOp op)
+        {
+            string elementName = "Spawn Features[" + index + "]";
+            DataEditForm frmData = new DataEditRootForm();
+            frmData.Title = DataEditor.GetWindowTitle("Spawn", elementName, element, typeof(MobSpawnExtra), new object[0]);
+
+            DataEditor.LoadClassControls(frmData.ControlPanel, "Spawn", null, elementName, typeof(MobSpawnExtra), new object[0], element, true, new Type[0], advancedEdit);
+            DataEditor.TrackTypeSize(frmData, typeof(MobSpawnExtra));
+            
+            frmData.SelectedOKEvent += async () =>
+            {
+                element = DataEditor.SaveClassControls(frmData.ControlPanel, elementName, typeof(MobSpawnExtra), new object[0], true, new Type[0], advancedEdit);
+                op(index, element);
+                return true;
+            };
+            
+            frmData.Show();
+        }
+        public TeamMemberSpawnModel()
+        {
+            TeamSpawn = new TeamMemberSpawn();
+            TeamSpawn.Spawn = new MobSpawn();
+            TeamSpawn.Spawn.Level.Min = 1;
+            TeamSpawn.Spawn.Level.Max = 1;
+            Initialize();
+            ChosenTactic = tacticKeys.BinarySearch("wander_normal");
+            MonsterData entry = DataManager.Instance.GetMonster("missingno");
+            BaseMonsterForm form = entry.Forms[0];
+            SearchMonsterFilter = form.FormName.ToLocal();
+            SelectedMonsterIndex = findMonsterForm("missingno", 0);
+        }
+        public TeamMemberSpawnModel(TeamMemberSpawn spawn)
+        {
+
+            string species = spawn.Spawn.BaseForm.Species == "" ? "missingno" : spawn.Spawn.BaseForm.Species;
+            MonsterData entry = DataManager.Instance.GetMonster(species);
+            BaseMonsterForm form = entry.Forms[spawn.Spawn.BaseForm.Form];
+            TeamSpawn = spawn;
+            
+            Initialize();
+            
+            _unrecruitable = containsType<MobSpawnExtra, MobSpawnUnrecruitable>(SpawnFeatures.GetList<List<MobSpawnExtra>>());
+            _disableUnusedSlots = containsType<MobSpawnExtra, MobSpawnMovesOff>(SpawnFeatures.GetList<List<MobSpawnExtra>>());
+            _isWeakMonster = containsType<MobSpawnExtra, MobSpawnWeak>(SpawnFeatures.GetList<List<MobSpawnExtra>>());
+            
+            _selectedMonsterIndex = findMonsterForm(TeamSpawn.Spawn.BaseForm.Species, TeamSpawn.Spawn.BaseForm.Form);
+            SelectedMonsterForm = monsterForms[_selectedMonsterIndex];
+
+            SearchMonsterFilter = form.FormName.ToLocal();
+            
+            if (TeamSpawn.Spawn.Intrinsic != "")
+            {
+                SelectedIntrinsicIndex = intrinsicKeys.BinarySearch(spawn.Spawn.Intrinsic);
+                SearchIntrinsicFilter = DataManager.Instance.GetIntrinsic(spawn.Spawn.Intrinsic).Name.ToLocal();
+            }
+            
+            SetFormPossibleSkills(TeamSpawn.Spawn.BaseForm.Species, TeamSpawn.Spawn.BaseForm.Form);
+            SetFormPossibleIntrinsics(TeamSpawn.Spawn.BaseForm.Species, TeamSpawn.Spawn.BaseForm.Form);
+            updateIntrinsicData(SearchIntrinsicFilter);
+            
+            for (int ii = 0; ii < CharData.MAX_SKILL_SLOTS; ii++)
+            {
+                string filter = "";
+                if (ii < spawn.Spawn.SpecifiedSkills.Count)
+                {
+                    string skillKey = spawn.Spawn.SpecifiedSkills[ii];
+                    filter = DataManager.Instance.GetSkill(skillKey).Name.ToLocal();
+                    int index = skillKeys.BinarySearch(skillKey);
+                    SkillIndex[ii] = index;
+                }
+                
+                if (ii == 0)
+                {
+                    _searchSkill0Filter = filter;
+                }
+                else if (ii == 1)
+                {
+                    _searchSkill1Filter = filter;
+                } 
+                else if (ii == 2)
+                {
+                    _searchSkill2Filter = filter;
+                    
+                }
+                else if (ii == 3)
+                {
+                    _searchSkill3Filter = filter;
+                }
+            }
+        }
+
+        public bool ShouldAddToFilter(string s, string filter)
+        {
+            return prefixStartsWith(s, filter) || startsWith(s, filter);
+        }
+
+        private bool containsType<T, V>(List<T> collection)
+        {
+            bool result = false;
+
+            foreach (T item in collection)
+            {
+                if (item is V)
+                {
+                    result = true;
+                    break;
+                }
+            }
+
+            return result;
+        }
+
+        private bool _finishedAdding;
+
+        public bool FinishedAdding
+        {
+            get => _finishedAdding;
+        }
+        private void addFilteredItems<T>(ObservableCollection<T> collection, IEnumerable<T> items)
+        {
+            if (items.Count() > 0)
+            {
+                _finishedAdding = false;
+                foreach (T item in items.Take(items.Count() - 1))
+                {
+                    collection.Add(item);
+                }
+
+                _finishedAdding = true;
+                collection.Add(items.Last());
+            }
+        }
+        
+        private List<string> getSkillList()
+        {
+            return SkillIndex.Where(i => i != -1).Select(i => skillKeys[i]).ToList();
+        }
+        
+        private int findMonsterForm(string species, int form)
+        {
+            
+            int result = -1;
+            for (int ii = 0; ii < monsterForms.Count(); ii++)
+            {
+                BaseMonsterFormViewModel vm = monsterForms[ii];
+                if (species == vm.Key && form == vm.FormId)
+                {
+                    result = ii;
+                    break;
+                }
+            }
+
+            return result;
+        }
+
+        public bool SanitizeStringEquals(string s1, string s2)
+        {
+            return sanitize(s1) == sanitize(s2);
+        }
+
+        private string sanitize(string s)
+        {
+            s = s.ToLower();
+            s = Regex.Replace(s, @"\s+|_", "");
+            return s;
+        }
+
+        private bool startsWith(string s, string filter)
+        {
+            return sanitize(s).StartsWith(sanitize(filter));
+        }
+
+        private bool prefixStartsWith(string s, string filter)
+        {
+            return s.Split(' ', '-').Any(prefix =>
+                sanitize(prefix).StartsWith(sanitize(filter), StringComparison.OrdinalIgnoreCase)
+            );
+        }
+
+        public void UpdateDataGrid()
+        {
+            DataGridType nextView = DataGridType.Monster;
+            if (FocusIndex >= 6)
+            {
+                nextView = DataGridType.Other;
+            }
+            else if (FocusIndex >= 5)
+            {
+                nextView = DataGridType.Intrinsic;
+            }
+            else if (FocusIndex >= 1)
+            {
+                nextView = DataGridType.Skills;
+            }
+
+            CurrentDataGridView = nextView;
+        }
+
+    }
+    
+    public enum DataGridType
+    {
+        Monster = 0,
+        Skills = 1,
+        Intrinsic = 2,
+        Other = 3,
+    } 
+    
+}

--- a/PMDC/Dev/Views/UserControls/TeamMemberSpawnView.axaml
+++ b/PMDC/Dev/Views/UserControls/TeamMemberSpawnView.axaml
@@ -1,0 +1,386 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:local="using:PMDC.Dev.ViewModels"
+             xmlns:vm="using:PMDC.Dev.ViewModels"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             xmlns:converters="clr-namespace:RogueEssence.Dev.Converters;assembly=RogueEssence.Editor.Avalonia"
+             xmlns:views="clr-namespace:PMDC.Dev.Views"
+             xmlns:rviews="clr-namespace:RogueEssence.Dev.Views;assembly=RogueEssence.Editor.Avalonia"
+             x:Class="PMDC.Dev.Views.TeamMemberSpawnView"
+             >
+
+    <Design.DataContext>
+        <vm:TeamMemberSpawnModel />    
+    </Design.DataContext>
+    <UserControl.Resources>
+        <converters:IsNoneOrEmptyConverter x:Key="IsNoneOrEmptyConverter"/>
+        <converters:IsNotNoneOrEmptyConverter x:Key="IsNotNoneOrEmptyConverter"/>
+        <converters:ComparisonConverter x:Key="ComparisonConverter"/>
+        <converters:OXConverter x:Key="OXConverter"/>
+        <converters:TypeConverter x:Key="TypeConverter"/>
+        <converters:CategoryConverter x:Key="CategoryConverter"/>
+        <SolidColorBrush x:Key="FocusColor">#54B4D3</SolidColorBrush>
+        <SolidColorBrush x:Key="BorderColor">#AAAAAA</SolidColorBrush>
+    </UserControl.Resources>
+    <UserControl.Styles>
+        <Style Selector="DataGrid TextBlock">
+            <Setter Property="TextWrapping" Value="WrapWithOverflow" />
+        </Style>
+        <Style Selector="DataGrid TextBox">
+            <Setter Property="TextWrapping" Value="Wrap" />
+            <Setter Property="AcceptsReturn" Value="True" />
+        </Style>
+        <Style Selector="DataGridCell.center_column">
+            <Setter Property="HorizontalContentAlignment" Value="Center" />
+        </Style>
+        <Style Selector="DataGridColumnHeader">
+            <Setter Property="HorizontalContentAlignment" Value="Center" />
+        </Style>
+        <Style Selector="TextBox:focus Border">
+            <Setter Property="BorderBrush" Value="{DynamicResource FocusColor}"/>
+        </Style>
+        <Style Selector="TextBox">
+            <Setter Property="Height" Value="32"/>
+            <Setter Property="Padding" Value="4, 6" />
+        </Style>
+        <Style Selector="ListBox">
+            <Setter Property="Margin" Value="0, 0, 0, 0"/>
+        </Style>
+        <Style Selector="TextBlock.header">
+            <Setter Property="Margin" Value="4, 0" />
+            <Setter Property="FontWeight" Value="Bold"/>
+            <Setter Property="FontSize" Value="16"/>
+            <Setter Property="Padding" Value="0, 4" />
+        </Style>
+        <Style Selector="Border.header">
+            <Setter Property="BorderBrush" Value="{DynamicResource BorderColor}"/>
+            <Setter Property="BorderThickness" Value="1, 1, 1, 0"/>
+        </Style>
+        <Style Selector="NumericUpDown">
+            <Setter Property="Height" Value="34"/>
+            <Setter Property="VerticalContentAlignment" Value="Center"/>
+        </Style>
+        <Style Selector="rviews|SearchComboBox">
+            <Setter Property="Height" Value="28"/>
+        </Style>
+        <Style Selector="DataGrid">
+            <Setter Property="Height" Value="500"/>
+        </Style>
+        <Style Selector="rviews|SearchComboBox:focus Border">
+            <Setter Property="BorderBrush" Value="{DynamicResource FocusColor}"/>
+        </Style>
+    </UserControl.Styles>
+
+    <Grid RowDefinitions="Auto, Auto, Auto, Auto">
+        <StackPanel Grid.Row="0">
+            <StackPanel.Styles>
+                <Style Selector="Border">
+                    <Setter Property="Margin" Value="0, 0, 6, 3" />
+                </Style>
+            </StackPanel.Styles>
+            <Grid ColumnDefinitions="*, *, *, *, *">
+                <StackPanel Grid.Column="0">
+                    <Border>
+                        <StackPanel>
+                            <TextBlock Text="Pokémon" FontWeight="Bold"></TextBlock>
+                            <TextBox
+                                     GotFocus="SpeciesTextBox_OnGotFocus"
+                                     LostFocus="SpeciesTextBox_OnLostFocus"
+                                     x:Name="SpeciesTextBox"
+                                     Text="{Binding SearchMonsterFilter, Mode=TwoWay}"
+                                     VerticalContentAlignment="Center">
+                                <TextBox.KeyBindings>
+                                    <KeyBinding Gesture="Enter" 
+                                                Command="{Binding $parent[views:TeamMemberSpawnView].SpeciesTextBox_OnEnterCommand}"/>
+                                </TextBox.KeyBindings>
+                            </TextBox>
+                            <TextBlock Text="Gender" FontWeight="Bold"></TextBlock>
+                            <rviews:SearchComboBox Items="{Binding Genders}" SelectedIndex="{Binding ChosenGender}" VerticalAlignment="Center" Margin="0,0" />
+                            <TextBlock Text="Skin" FontWeight="Bold"></TextBlock>
+                            <rviews:SearchComboBox Items="{Binding Skins}" SelectedIndex="{Binding ChosenSkin}" VerticalAlignment="Center" Margin="0,0" />
+                            <CheckBox  IsChecked="{Binding IsWeakMob}">Weak</CheckBox>
+                            <CheckBox IsChecked="{Binding Unrecruitable}" Margin="0, 0, 0, 0">Unrecruitable</CheckBox>
+                        </StackPanel>
+                    </Border>
+                </StackPanel>
+                <StackPanel Grid.Column="1">
+                    <Border>
+                        <StackPanel>
+                            <TextBlock Text="Moves" FontWeight="Bold"></TextBlock>
+                            <TextBox 
+                                x:Name="SkillTextBox0"
+                                GotFocus="SkillTextBox0_OnGotFocus"
+                                LostFocus="SkillTextBox0_OnLostFocus"
+                                Text="{Binding SearchSkill0Filter, Mode=TwoWay}"
+                                VerticalContentAlignment="Center">
+                                <TextBox.KeyBindings>
+                                    <KeyBinding Gesture="Enter" 
+                                                Command="{Binding $parent[views:TeamMemberSpawnView].SkillTextBox_OnEnterCommand}"/>
+                                </TextBox.KeyBindings>
+                            </TextBox>
+                            <TextBox 
+                                x:Name="SkillTextBox1"
+                                GotFocus="SkillTextBox1_OnGotFocus"
+                                LostFocus="SkillTextBox1_OnLostFocus"
+                                Text="{Binding SearchSkill1Filter, Mode=TwoWay}"
+                                VerticalContentAlignment="Center">
+                                <TextBox.KeyBindings>
+                                    <KeyBinding Gesture="Enter" 
+                                                Command="{Binding $parent[views:TeamMemberSpawnView].SkillTextBox_OnEnterCommand}"/>
+                                </TextBox.KeyBindings>
+                            </TextBox>
+                            <TextBox 
+                                x:Name="SkillTextBox2"
+                                Text="{Binding SearchSkill2Filter, Mode=TwoWay}"
+                                GotFocus="SkillTextBox2_OnGotFocus"
+                                LostFocus="SkillTextBox2_OnLostFocus"
+                                VerticalContentAlignment="Center">
+                                <TextBox.KeyBindings>
+                                    <KeyBinding Gesture="Enter" 
+                                                Command="{Binding $parent[views:TeamMemberSpawnView].SkillTextBox_OnEnterCommand}"/>
+                                </TextBox.KeyBindings>
+                            </TextBox>
+                            <TextBox 
+                                x:Name="SkillTextBox3"
+                                Text="{Binding SearchSkill3Filter, Mode=TwoWay}"
+                                GotFocus="SkillTextBox3_OnGotFocus"
+                                LostFocus="SkillTextBox3_OnLostFocus"
+                                VerticalContentAlignment="Center">
+                                <TextBox.KeyBindings>
+                                    <KeyBinding Gesture="Enter" 
+                                                Command="{Binding $parent[views:TeamMemberSpawnView].SkillTextBox_OnEnterCommand}"/>
+                                </TextBox.KeyBindings>
+                            </TextBox>
+                            <CheckBox IsChecked="{Binding DisableUnusedSlots}">Disable Unused Slots</CheckBox>
+                        </StackPanel>
+                    </Border>
+                </StackPanel>
+                 <StackPanel Grid.Column="2">
+                    <Border>
+                        <StackPanel>
+                            <TextBlock Text="Ability" FontWeight="Bold"></TextBlock>
+                            <TextBox 
+                                x:Name="IntrinsicTextBox"
+                                Text="{Binding SearchIntrinsicFilter, Mode=TwoWay}"
+                                GotFocus="IntrinsicTextBox_OnGotFocus"
+                                LostFocus="IntrinsicTextBox_OnLostFocus"
+                                VerticalContentAlignment="Center">
+                                <TextBox.KeyBindings>
+                                    <KeyBinding Gesture="Enter" 
+                                                Command="{Binding $parent[views:TeamMemberSpawnView].IntrinsicTextBox_OnEnterCommand}"/>
+                                </TextBox.KeyBindings>
+                            </TextBox>
+                            
+                       
+                            <TextBlock Text="Level Range" FontWeight="Bold"></TextBlock>
+                            <Grid ColumnDefinitions="4*, *, 4*" Margin="0, 0, 0, 4">
+                                <NumericUpDown
+                                    x:Name="MinTextBox"
+                                    Minimum="1" 
+                                    Maximum="100" 
+                                    Watermark="Min"
+                                    Value="{Binding Min}"
+                                    ValueChanged="MinTextBox_OnValueChanged"
+                                    GotFocus="MinTextBox_OnGotFocus"
+                                />
+                                <NumericUpDown
+                                    Grid.Column="2"
+                                    x:Name="MaxTextBox"  
+                                    Minimum="1" 
+                                    Maximum="100" 
+                                    Margin="-4, 0, 6, 0"
+                                    Watermark="Min"
+                                    Value="{Binding Max}"
+                                    ValueChanged="MaxTextBox_OnValueChanged"
+                                    GotFocus="MaxTextBox_OnGotFocus"
+                                />
+                            </Grid>
+                            <TextBlock Text="Tactic" FontWeight="Bold"></TextBlock>
+                            <rviews:SearchComboBox Items="{Binding Tactics}" SelectedIndex="{Binding ChosenTactic}" VerticalAlignment="Center" Margin="0,0"/>
+                            <TextBlock Text="Role" FontWeight="Bold"></TextBlock>
+                            <rviews:SearchComboBox Items="{Binding Roles}" SelectedIndex="{Binding ChosenRole}" VerticalAlignment="Center" Margin="0,0"/>
+                        </StackPanel>
+                    </Border>
+                </StackPanel>
+                <Grid Grid.Column="3" RowDefinitions="Auto, Auto">
+                    <TextBlock VerticalAlignment="Bottom" Grid.Row="0">Spawn Checks</TextBlock>
+                    <rviews:CollectionBox DataContext="{Binding SpawnConditions}" Margin="0, 0, 0, 4" Grid.Row="1" Height="157"/>
+                </Grid>
+                <Grid Grid.Column="4" RowDefinitions="Auto, Auto">
+                    <TextBlock VerticalAlignment="Bottom" Grid.Row="0">Spawn Features </TextBlock>
+                    <rviews:CollectionBox DataContext="{Binding SpawnFeatures}" Margin="0, 0, 0, 4" Grid.Row="1" Height="157"/>
+                </Grid>
+            </Grid>
+            <Rectangle Height="1" Stroke="{DynamicResource BorderColor}" Fill="{DynamicResource BorderColor}" StrokeThickness="1" Stretch="Fill" Margin="0, 6"></Rectangle>
+        </StackPanel>
+        
+        <Grid Grid.Row="3">
+            <!-- MONSTERS -->
+            <Grid RowDefinitions="Auto, Auto, Auto" IsVisible="{Binding CurrentDataGridView, Converter={StaticResource ComparisonConverter}, ConverterParameter={x:Static vm:DataGridType.Monster }}">
+                <Grid Grid.Row="0" ColumnDefinitions="Auto, Auto" Margin="0, 0, 0, 6">
+                    <CheckBox Grid.Column="0" IsChecked="{Binding IncludeUnreleasedForms}" Margin="0, 0, 6, 0">Include Unreleased</CheckBox>
+                    <CheckBox Grid.Column="1" IsChecked="{Binding IncludeTemporaryForms}">Include Temporary</CheckBox>
+                </Grid>
+                <Border Grid.Row="1" Classes="header">
+                    <TextBlock Classes="header" >Pokémon</TextBlock>
+                </Border>
+                <DataGrid Grid.Row="2" Name="BaseMonsterDataGrid"
+                  Items="{Binding FilteredMonsterForms}"
+                  HorizontalScrollBarVisibility="Disabled"
+                  Margin="0" 
+                  RowHeight="50"
+                  SelectedItem="{Binding SelectedMonsterForm, Mode=TwoWay}"
+                  CellPointerPressed="MonsterDataGrid_OnCellPointerPressed"
+                  >
+                    <DataGrid.Columns>
+                        <DataGridTextColumn Header="" CanUserSort="False" Binding="{Binding Name}" Width="300"/>
+                        <DataGridTemplateColumn Header="Types" Width="160"  >
+                            <DataGridTemplateColumn.CellTemplate>
+                                <DataTemplate DataType="vm:BaseMonsterFormViewModel">
+                                    <Grid ColumnDefinitions="8, *, 20, *, 8" >
+                                        <Grid Grid.Column="1" RowDefinitions="20, Auto" HorizontalAlignment="Center" VerticalAlignment="Center">
+                                            <Image Source="{Binding Element1, Converter={StaticResource TypeConverter}}" Height="20" />
+                                            <TextBlock Grid.Row="1" Text="{Binding Element1Display}" HorizontalAlignment="Center" />
+                                        </Grid>
+                                        <Grid Grid.Column="3" RowDefinitions="20, Auto" HorizontalAlignment="Center" VerticalAlignment="Center" IsVisible="{Binding Element2, Converter={StaticResource IsNotNoneOrEmptyConverter}}" >
+                                            <Image Grid.Column="0" Source="{Binding Element2, Converter={StaticResource TypeConverter}}" Height="20" />
+                                            <TextBlock Grid.Row="1" Text="{Binding Element2Display}" HorizontalAlignment="Center" />
+                                        </Grid>
+                                    </Grid>
+                                 </DataTemplate>
+                             </DataGridTemplateColumn.CellTemplate>
+                         </DataGridTemplateColumn>
+                        <DataGridTemplateColumn Width="300" Header="Abilities">
+                             <DataGridTemplateColumn.CellTemplate>
+                                 <DataTemplate DataType="vm:BaseMonsterFormViewModel">
+                                     <Grid ColumnDefinitions="*, *">
+                                         <Grid Grid.Column="0" RowDefinitions="*, *" VerticalAlignment="Center" HorizontalAlignment="Center">
+                                             <TextBlock HorizontalAlignment="Center" Text="{Binding Intrinsic1}" IsVisible="{Binding Intrinsic1, Converter={StaticResource IsNotNoneOrEmptyConverter}}"/>
+                                             <TextBlock Grid.Row="1" HorizontalAlignment="Center"  Text="{Binding Intrinsic2}">
+                                                 <TextBlock.IsVisible>
+                                                     <MultiBinding Converter="{x:Static BoolConverters.And}">
+                                                         <Binding Path="Intrinsic2" Converter="{StaticResource IsNotNoneOrEmptyConverter}"/>
+                                                         <Binding Path="Intrinsic3" Converter="{StaticResource IsNotNoneOrEmptyConverter}"/>
+                                                     </MultiBinding>
+                                                 </TextBlock.IsVisible>
+                                             </TextBlock>
+                                         </Grid>
+                                         <Grid Grid.Column="1" RowDefinitions="*, *" VerticalAlignment="Center" HorizontalAlignment="Center">
+                                             <TextBlock Grid.Row="0" HorizontalAlignment="Center"  Text="{Binding Intrinsic2}">
+                                                 <TextBlock.IsVisible>
+                                                     <MultiBinding Converter="{x:Static BoolConverters.And}">
+                                                         <Binding Path="Intrinsic2" Converter="{StaticResource IsNotNoneOrEmptyConverter}"/>
+                                                         <Binding Path="Intrinsic3" Converter="{StaticResource IsNoneOrEmptyConverter}"/>
+                                                     </MultiBinding>
+                                                 </TextBlock.IsVisible>
+                                             </TextBlock>
+                                             <TextBlock Grid.Row="1" HorizontalAlignment="Center"  Text="{Binding Intrinsic3}">
+                                                 <TextBlock.IsVisible>
+                                                     <Binding Path="Intrinsic3" Converter="{StaticResource IsNotNoneOrEmptyConverter}"/>
+                                                 </TextBlock.IsVisible>
+                                             </TextBlock>
+                                         </Grid>
+                                     </Grid>
+                                 </DataTemplate>
+                             </DataGridTemplateColumn.CellTemplate>
+                         </DataGridTemplateColumn>
+                        <DataGridTextColumn Header="HP" CellStyleClasses="center_column" Binding="{Binding BaseHP}" Width="Auto" />
+                        <DataGridTextColumn Header="Atk" CellStyleClasses="center_column" Binding="{Binding BaseAtk}" Width="Auto" />
+                        <DataGridTextColumn Header="Def" CellStyleClasses="center_column" Binding="{Binding BaseDef}" Width="Auto" />
+                        <DataGridTextColumn Header="SpA" CellStyleClasses="center_column" Binding="{Binding BaseMAtk}" Width="Auto" />
+                        <DataGridTextColumn Header="SpD" CellStyleClasses="center_column" Binding="{Binding BaseMDef}" Width="Auto" />
+                        <DataGridTextColumn Header="Spe" CellStyleClasses="center_column" Binding="{Binding BaseSpeed}" Width="Auto" />
+                        <DataGridTextColumn Header="BST" CellStyleClasses="center_column" Binding="{Binding BaseTotal}" Width="Auto" />
+                    </DataGrid.Columns>
+                </DataGrid>
+            </Grid>
+            
+            <Grid RowDefinitions="Auto, Auto, Auto" IsVisible="{Binding CurrentDataGridView, Converter={StaticResource ComparisonConverter}, ConverterParameter={x:Static vm:DataGridType.Skills }}">
+                <Grid Grid.Row="0" RowDefinitions="Auto" Margin="0, 0, 0, 6">
+                    <CheckBox IsChecked="{Binding IncludeUnreleasedSkills}">Include Unreleased</CheckBox>
+                </Grid>
+                <Border Grid.Row="1" Classes="header">
+                    <TextBlock Classes="header">Moves</TextBlock>
+                </Border>
+                <DataGrid Grid.Row="2" Name="SkillsDataGrid"
+                  Items="{Binding FilteredSkillData}"
+                  CanUserResizeColumns="False"
+                  HorizontalScrollBarVisibility="Disabled"
+                  Margin="0" 
+                  RowHeight="50"
+                  SelectedItem="{Binding SelectedSkillData, Mode=TwoWay}"
+                  CellPointerPressed="SkillsDataGrid_OnCellPointerPressed"
+                  >
+                    <DataGrid.Columns>
+                        <DataGridTemplateColumn Width="300" Header="">
+                            <DataGridTemplateColumn.CellTemplate>
+                                <DataTemplate DataType="vm:SkillDataViewModel">
+                                    <Grid ColumnDefinitions="24, Auto">
+                                        <Image Source="{Binding MonsterLearns, Converter={StaticResource OXConverter}}" Stretch="None" Grid.Column="0"/>
+                                        <TextBlock Text="{Binding Name}" VerticalAlignment="Center" Grid.Column="1"/>
+                                    </Grid>
+                                </DataTemplate>
+                            </DataGridTemplateColumn.CellTemplate>
+                        </DataGridTemplateColumn>
+                        <DataGridTemplateColumn Header="Type" Width="60" SortMemberPath="Element">
+                            <DataGridTemplateColumn.CellTemplate>
+                                <DataTemplate DataType="vm:SkillDataViewModel">
+                                    <Grid RowDefinitions="20, Auto" HorizontalAlignment="Center" VerticalAlignment="Center">
+                                        <Image Source="{Binding Element, Converter={StaticResource TypeConverter}}" Height="20" />
+                                        <TextBlock Grid.Row="1" Text="{Binding ElementDisplay}" HorizontalAlignment="Center" />
+                                    </Grid>
+                                </DataTemplate>
+                            </DataGridTemplateColumn.CellTemplate>
+                        </DataGridTemplateColumn>
+                        <DataGridTemplateColumn Header="Cat" Width="Auto" SortMemberPath="Category">
+                            <DataGridTemplateColumn.CellTemplate>
+                                <DataTemplate DataType="vm:SkillDataViewModel">
+                                    <Image Source="{Binding Category, Converter={StaticResource CategoryConverter}}" Height="20" />
+                                </DataTemplate>
+                            </DataGridTemplateColumn.CellTemplate>
+                        </DataGridTemplateColumn>
+                        <DataGridTextColumn Header="Pow" CellStyleClasses="center_column" Binding="{Binding BasePower}" Width="Auto" />
+                        <DataGridTextColumn Header="Acc" CellStyleClasses="center_column" Binding="{Binding Accuracy}" Width="Auto" />
+                        <DataGridTextColumn Header="PP" CellStyleClasses="center_column" Binding="{Binding BaseCharges}" Width="Auto" />
+                        <DataGridTextColumn Header="Range" CellStyleClasses="center_column"  Binding="{Binding RangeDescription}" Width="150" />
+                        <DataGridTextColumn Header="Description" Binding="{Binding Description}" Width="300" />
+                    </DataGrid.Columns>
+                </DataGrid>
+            </Grid>
+            
+            <!-- INTRINSIC -->
+            <Grid RowDefinitions="Auto, Auto, Auto" IsVisible="{Binding CurrentDataGridView, Converter={StaticResource ComparisonConverter}, ConverterParameter={x:Static local:DataGridType.Intrinsic }}">
+                <Grid Grid.Row="0" RowDefinitions="Auto" Margin="0, 0, 0, 6">
+                    <CheckBox IsChecked="{Binding IncludeUnreleasedIntrinsics}">Include Unreleased</CheckBox>
+                </Grid>
+                <Border Grid.Row="1" Classes="header">
+                    <TextBlock Classes="header">Abilities</TextBlock>
+                </Border>
+                <DataGrid Grid.Row="2" Name="IntrinsicDataGrid"
+                  Items="{Binding FilteredIntrinsicData}"
+                  HorizontalScrollBarVisibility="Disabled"
+                  Margin="0" 
+                  RowHeight="50"
+                  SelectedItem="{Binding SelectedIntrinsic, Mode=TwoWay}"
+                  CellPointerPressed="IntrinsicDataGrid_OnCellPointerPressed"
+                  >
+                    <DataGrid.Columns>
+                        <DataGridTemplateColumn Width="300" SortMemberPath="Name" Header="">
+                            <DataGridTemplateColumn.CellTemplate>
+                                <DataTemplate DataType="vm:IntrinsicViewModel">
+                                    <Grid ColumnDefinitions="24, Auto">
+                                        <Image Source="{Binding MonsterLearns, Converter={StaticResource OXConverter}}" Stretch="None" Grid.Column="0"/>
+                                        <TextBlock Text="{Binding Name}" VerticalAlignment="Center" Grid.Column="1"/>
+                                    </Grid>
+                                </DataTemplate>
+                            </DataGridTemplateColumn.CellTemplate>
+                        </DataGridTemplateColumn>
+                        <DataGridTextColumn Header="Description" Binding="{Binding Description}" Width="600" />
+                    </DataGrid.Columns>
+                </DataGrid>
+            </Grid>
+        </Grid>
+    </Grid>
+</UserControl>

--- a/PMDC/Dev/Views/UserControls/TeamMemberSpawnView.axaml
+++ b/PMDC/Dev/Views/UserControls/TeamMemberSpawnView.axaml
@@ -19,8 +19,8 @@
         <converters:IsNotNoneOrEmptyConverter x:Key="IsNotNoneOrEmptyConverter"/>
         <converters:ComparisonConverter x:Key="ComparisonConverter"/>
         <converters:OXConverter x:Key="OXConverter"/>
-        <converters:TypeConverter x:Key="TypeConverter"/>
-        <converters:CategoryConverter x:Key="CategoryConverter"/>
+        <converters:ElementIconConverter x:Key="ElementIconConverter"/>
+        <converters:SkillCategoryIconConverter x:Key="SkillCategoryIconConverter"/>
         <SolidColorBrush x:Key="FocusColor">#54B4D3</SolidColorBrush>
         <SolidColorBrush x:Key="BorderColor">#AAAAAA</SolidColorBrush>
     </UserControl.Resources>
@@ -241,11 +241,11 @@
                                 <DataTemplate DataType="vm:BaseMonsterFormViewModel">
                                     <Grid ColumnDefinitions="8, *, 20, *, 8" >
                                         <Grid Grid.Column="1" RowDefinitions="20, Auto" HorizontalAlignment="Center" VerticalAlignment="Center">
-                                            <Image Source="{Binding Element1, Converter={StaticResource TypeConverter}}" Height="20" />
+                                            <Image Source="{Binding Element1, Converter={StaticResource ElementIconConverter}}" Height="20" />
                                             <TextBlock Grid.Row="1" Text="{Binding Element1Display}" HorizontalAlignment="Center" />
                                         </Grid>
-                                        <Grid Grid.Column="3" RowDefinitions="20, Auto" HorizontalAlignment="Center" VerticalAlignment="Center" IsVisible="{Binding Element2, Converter={StaticResource IsNotNoneOrEmptyConverter}}" >
-                                            <Image Grid.Column="0" Source="{Binding Element2, Converter={StaticResource TypeConverter}}" Height="20" />
+                                        <Grid Grid.Column="3" RowDefinitions="20, Auto" HorizontalAlignment="Center" VerticalAlignment="Center" IsVisible="{Binding Element2, Converter={StaticResource IsNotNoneOrEmptyConverter}, ConverterParameter=2048}" >
+                                            <Image Grid.Column="0" Source="{Binding Element2, Converter={StaticResource ElementIconConverter}}" Height="20" />
                                             <TextBlock Grid.Row="1" Text="{Binding Element2Display}" HorizontalAlignment="Center" />
                                         </Grid>
                                     </Grid>
@@ -257,12 +257,12 @@
                                  <DataTemplate DataType="vm:BaseMonsterFormViewModel">
                                      <Grid ColumnDefinitions="*, *">
                                          <Grid Grid.Column="0" RowDefinitions="*, *" VerticalAlignment="Center" HorizontalAlignment="Center">
-                                             <TextBlock HorizontalAlignment="Center" Text="{Binding Intrinsic1}" IsVisible="{Binding Intrinsic1, Converter={StaticResource IsNotNoneOrEmptyConverter}}"/>
+                                             <TextBlock HorizontalAlignment="Center" Text="{Binding Intrinsic1}" IsVisible="{Binding Intrinsic1, Converter={StaticResource IsNotNoneOrEmptyConverter}, ConverterParameter=2048}"/>
                                              <TextBlock Grid.Row="1" HorizontalAlignment="Center"  Text="{Binding Intrinsic2}">
                                                  <TextBlock.IsVisible>
                                                      <MultiBinding Converter="{x:Static BoolConverters.And}">
-                                                         <Binding Path="Intrinsic2" Converter="{StaticResource IsNotNoneOrEmptyConverter}"/>
-                                                         <Binding Path="Intrinsic3" Converter="{StaticResource IsNotNoneOrEmptyConverter}"/>
+                                                         <Binding Path="Intrinsic2" Converter="{StaticResource IsNotNoneOrEmptyConverter}, ConverterParameter=2048"/>
+                                                         <Binding Path="Intrinsic3" Converter="{StaticResource IsNotNoneOrEmptyConverter}, ConverterParameter=2048"/>
                                                      </MultiBinding>
                                                  </TextBlock.IsVisible>
                                              </TextBlock>
@@ -271,14 +271,14 @@
                                              <TextBlock Grid.Row="0" HorizontalAlignment="Center"  Text="{Binding Intrinsic2}">
                                                  <TextBlock.IsVisible>
                                                      <MultiBinding Converter="{x:Static BoolConverters.And}">
-                                                         <Binding Path="Intrinsic2" Converter="{StaticResource IsNotNoneOrEmptyConverter}"/>
-                                                         <Binding Path="Intrinsic3" Converter="{StaticResource IsNoneOrEmptyConverter}"/>
+                                                         <Binding Path="Intrinsic2" Converter="{StaticResource IsNotNoneOrEmptyConverter}, ConverterParameter=2048"/>
+                                                         <Binding Path="Intrinsic3" Converter="{StaticResource IsNoneOrEmptyConverter}, ConverterParameter=2048"/>
                                                      </MultiBinding>
                                                  </TextBlock.IsVisible>
                                              </TextBlock>
                                              <TextBlock Grid.Row="1" HorizontalAlignment="Center"  Text="{Binding Intrinsic3}">
                                                  <TextBlock.IsVisible>
-                                                     <Binding Path="Intrinsic3" Converter="{StaticResource IsNotNoneOrEmptyConverter}"/>
+                                                     <Binding Path="Intrinsic3" Converter="{StaticResource IsNotNoneOrEmptyConverter}, ConverterParameter=2048"/>
                                                  </TextBlock.IsVisible>
                                              </TextBlock>
                                          </Grid>
@@ -328,7 +328,7 @@
                             <DataGridTemplateColumn.CellTemplate>
                                 <DataTemplate DataType="vm:SkillDataViewModel">
                                     <Grid RowDefinitions="20, Auto" HorizontalAlignment="Center" VerticalAlignment="Center">
-                                        <Image Source="{Binding Element, Converter={StaticResource TypeConverter}}" Height="20" />
+                                        <Image Source="{Binding Element, Converter={StaticResource ElementIconConverter}}" Height="20" />
                                         <TextBlock Grid.Row="1" Text="{Binding ElementDisplay}" HorizontalAlignment="Center" />
                                     </Grid>
                                 </DataTemplate>
@@ -337,7 +337,7 @@
                         <DataGridTemplateColumn Header="Cat" Width="Auto" SortMemberPath="Category">
                             <DataGridTemplateColumn.CellTemplate>
                                 <DataTemplate DataType="vm:SkillDataViewModel">
-                                    <Image Source="{Binding Category, Converter={StaticResource CategoryConverter}}" Height="20" />
+                                    <Image Source="{Binding Category, Converter={StaticResource ElementIconConverter}}" Height="20" />
                                 </DataTemplate>
                             </DataGridTemplateColumn.CellTemplate>
                         </DataGridTemplateColumn>

--- a/PMDC/Dev/Views/UserControls/TeamMemberSpawnView.axaml
+++ b/PMDC/Dev/Views/UserControls/TeamMemberSpawnView.axaml
@@ -42,7 +42,7 @@
             <Setter Property="BorderBrush" Value="{DynamicResource FocusColor}"/>
         </Style>
         <Style Selector="TextBox">
-            <Setter Property="Height" Value="32"/>
+            <Setter Property="Height" Value="36"/>
             <Setter Property="Padding" Value="4, 6" />
         </Style>
         <Style Selector="ListBox">
@@ -59,7 +59,7 @@
             <Setter Property="BorderThickness" Value="1, 1, 1, 0"/>
         </Style>
         <Style Selector="NumericUpDown">
-            <Setter Property="Height" Value="34"/>
+            <Setter Property="Height" Value="38"/>
             <Setter Property="VerticalContentAlignment" Value="Center"/>
         </Style>
         <Style Selector="rviews|SearchComboBox">
@@ -96,19 +96,19 @@
                                                 Command="{Binding $parent[views:TeamMemberSpawnView].SpeciesTextBox_OnEnterCommand}"/>
                                 </TextBox.KeyBindings>
                             </TextBox>
-                            <TextBlock Text="Gender" FontWeight="Bold"></TextBlock>
+                            <TextBlock Text="Gender"></TextBlock>
                             <rviews:SearchComboBox Items="{Binding Genders}" SelectedIndex="{Binding ChosenGender}" VerticalAlignment="Center" Margin="0,0" />
-                            <TextBlock Text="Skin" FontWeight="Bold"></TextBlock>
+                            <TextBlock Text="Skin"></TextBlock>
                             <rviews:SearchComboBox Items="{Binding Skins}" SelectedIndex="{Binding ChosenSkin}" VerticalAlignment="Center" Margin="0,0" />
-                            <CheckBox  IsChecked="{Binding IsWeakMob}">Weak</CheckBox>
-                            <CheckBox IsChecked="{Binding Unrecruitable}" Margin="0, 0, 0, 0">Unrecruitable</CheckBox>
+                            <CheckBox IsChecked="{Binding IsWeakMob}">Weak</CheckBox>
+                            <CheckBox IsChecked="{Binding Unrecruitable}">Unrecruitable</CheckBox>
                         </StackPanel>
                     </Border>
                 </StackPanel>
                 <StackPanel Grid.Column="1">
                     <Border>
                         <StackPanel>
-                            <TextBlock Text="Moves" FontWeight="Bold"></TextBlock>
+                            <TextBlock Text="Moves"></TextBlock>
                             <TextBox 
                                 x:Name="SkillTextBox0"
                                 GotFocus="SkillTextBox0_OnGotFocus"
@@ -160,7 +160,7 @@
                  <StackPanel Grid.Column="2">
                     <Border>
                         <StackPanel>
-                            <TextBlock Text="Ability" FontWeight="Bold"></TextBlock>
+                            <TextBlock Text="Ability"></TextBlock>
                             <TextBox 
                                 x:Name="IntrinsicTextBox"
                                 Text="{Binding SearchIntrinsicFilter, Mode=TwoWay}"
@@ -174,7 +174,7 @@
                             </TextBox>
                             
                        
-                            <TextBlock Text="Level Range" FontWeight="Bold"></TextBlock>
+                            <TextBlock Text="Level Range"></TextBlock>
                             <Grid ColumnDefinitions="4*, *, 4*" Margin="0, 0, 0, 4">
                                 <NumericUpDown
                                     x:Name="MinTextBox"
@@ -197,20 +197,21 @@
                                     GotFocus="MaxTextBox_OnGotFocus"
                                 />
                             </Grid>
-                            <TextBlock Text="Tactic" FontWeight="Bold"></TextBlock>
+                            <TextBlock Text="Tactic"></TextBlock>
                             <rviews:SearchComboBox Items="{Binding Tactics}" SelectedIndex="{Binding ChosenTactic}" VerticalAlignment="Center" Margin="0,0"/>
-                            <TextBlock Text="Role" FontWeight="Bold"></TextBlock>
+                            <TextBlock Text="Role"></TextBlock>
                             <rviews:SearchComboBox Items="{Binding Roles}" SelectedIndex="{Binding ChosenRole}" VerticalAlignment="Center" Margin="0,0"/>
                         </StackPanel>
                     </Border>
                 </StackPanel>
+                
                 <Grid Grid.Column="3" RowDefinitions="Auto, Auto">
-                    <TextBlock VerticalAlignment="Bottom" Grid.Row="0">Spawn Checks</TextBlock>
-                    <rviews:CollectionBox DataContext="{Binding SpawnConditions}" Margin="0, 0, 0, 4" Grid.Row="1" Height="157"/>
+                    <TextBlock VerticalAlignment="Bottom" Grid.Row="0">Spawn Features </TextBlock>
+                    <rviews:CollectionBox DataContext="{Binding SpawnFeatures}" Margin="0, 0, 0, 4" Grid.Row="1" Height="166"/>
                 </Grid>
                 <Grid Grid.Column="4" RowDefinitions="Auto, Auto">
-                    <TextBlock VerticalAlignment="Bottom" Grid.Row="0">Spawn Features </TextBlock>
-                    <rviews:CollectionBox DataContext="{Binding SpawnFeatures}" Margin="0, 0, 0, 4" Grid.Row="1" Height="157"/>
+                    <TextBlock VerticalAlignment="Bottom" Grid.Row="0">Spawn Checks</TextBlock>
+                    <rviews:CollectionBox DataContext="{Binding SpawnConditions}" Margin="0, 0, 0, 4" Grid.Row="1" Height="166"/>
                 </Grid>
             </Grid>
             <Rectangle Height="1" Stroke="{DynamicResource BorderColor}" Fill="{DynamicResource BorderColor}" StrokeThickness="1" Stretch="Fill" Margin="0, 6"></Rectangle>
@@ -257,12 +258,13 @@
                                  <DataTemplate DataType="vm:BaseMonsterFormViewModel">
                                      <Grid ColumnDefinitions="*, *">
                                          <Grid Grid.Column="0" RowDefinitions="*, *" VerticalAlignment="Center" HorizontalAlignment="Center">
-                                             <TextBlock HorizontalAlignment="Center" Text="{Binding Intrinsic1}" IsVisible="{Binding Intrinsic1, Converter={StaticResource IsNotNoneOrEmptyConverter}, ConverterParameter=2048}"/>
+                                             <TextBlock HorizontalAlignment="Center" Text="{Binding Intrinsic1}" IsVisible="{Binding Intrinsic1, Converter={StaticResource IsNotNoneOrEmptyConverter}, ConverterParameter='8'}"/>
                                              <TextBlock Grid.Row="1" HorizontalAlignment="Center"  Text="{Binding Intrinsic2}">
                                                  <TextBlock.IsVisible>
                                                      <MultiBinding Converter="{x:Static BoolConverters.And}">
-                                                         <Binding Path="Intrinsic2" Converter="{StaticResource IsNotNoneOrEmptyConverter}, ConverterParameter=2048"/>
-                                                         <Binding Path="Intrinsic3" Converter="{StaticResource IsNotNoneOrEmptyConverter}, ConverterParameter=2048"/>
+                                                         <Binding Path="Intrinsic2" Converter="{StaticResource IsNotNoneOrEmptyConverter}" ConverterParameter="8"/>
+
+                                                         <Binding Path="Intrinsic3" Converter="{StaticResource IsNotNoneOrEmptyConverter}" ConverterParameter="8"/>
                                                      </MultiBinding>
                                                  </TextBlock.IsVisible>
                                              </TextBlock>
@@ -271,14 +273,14 @@
                                              <TextBlock Grid.Row="0" HorizontalAlignment="Center"  Text="{Binding Intrinsic2}">
                                                  <TextBlock.IsVisible>
                                                      <MultiBinding Converter="{x:Static BoolConverters.And}">
-                                                         <Binding Path="Intrinsic2" Converter="{StaticResource IsNotNoneOrEmptyConverter}, ConverterParameter=2048"/>
-                                                         <Binding Path="Intrinsic3" Converter="{StaticResource IsNoneOrEmptyConverter}, ConverterParameter=2048"/>
+                                                         <Binding Path="Intrinsic2" Converter="{StaticResource IsNotNoneOrEmptyConverter}"  ConverterParameter="8"/>
+                                                         <Binding Path="Intrinsic3" Converter="{StaticResource IsNoneOrEmptyConverter}"  ConverterParameter="8" />
                                                      </MultiBinding>
                                                  </TextBlock.IsVisible>
                                              </TextBlock>
                                              <TextBlock Grid.Row="1" HorizontalAlignment="Center"  Text="{Binding Intrinsic3}">
                                                  <TextBlock.IsVisible>
-                                                     <Binding Path="Intrinsic3" Converter="{StaticResource IsNotNoneOrEmptyConverter}, ConverterParameter=2048"/>
+                                                     <Binding Path="Intrinsic3" Converter="{StaticResource IsNotNoneOrEmptyConverter}" ConverterParameter="8"/>
                                                  </TextBlock.IsVisible>
                                              </TextBlock>
                                          </Grid>
@@ -337,7 +339,7 @@
                         <DataGridTemplateColumn Header="Cat" Width="Auto" SortMemberPath="Category">
                             <DataGridTemplateColumn.CellTemplate>
                                 <DataTemplate DataType="vm:SkillDataViewModel">
-                                    <Image Source="{Binding Category, Converter={StaticResource ElementIconConverter}}" Height="20" />
+                                    <Image Source="{Binding Category, Converter={StaticResource SkillCategoryIconConverter}}" Height="20" />
                                 </DataTemplate>
                             </DataGridTemplateColumn.CellTemplate>
                         </DataGridTemplateColumn>

--- a/PMDC/Dev/Views/UserControls/TeamMemberSpawnView.axaml.cs
+++ b/PMDC/Dev/Views/UserControls/TeamMemberSpawnView.axaml.cs
@@ -1,0 +1,414 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Linq;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.LogicalTree;
+using Avalonia.Markup.Xaml;
+using Avalonia.Threading;
+using PMDC.Dev.ViewModels;
+using RogueEssence.Dev;
+
+namespace PMDC.Dev.Views
+{
+    public class TeamMemberSpawnView : UserControl
+    {
+               
+        private List<string> _focusOrder = new List<string> { 
+            "SpeciesTextBox", "SkillTextBox0", "SkillTextBox1", 
+            "SkillTextBox2", "SkillTextBox3", "IntrinsicTextBox",
+            "MinTextBox", "MaxTextBox"
+        };
+        
+    
+        public TeamMemberSpawnView()
+        {
+            this.InitializeComponent();
+        }
+
+        private void InitializeComponent()
+        {
+            AvaloniaXamlLoader.Load(this);
+
+        }
+        
+        protected override void OnInitialized()
+        {
+            base.OnInitialized();
+            if (DataContext is TeamMemberSpawnModel vm)
+            {
+                vm.FilteredSkillData.CollectionChanged += FilteredSkillDataOnCollectionChanged;
+                vm.FilteredMonsterForms.CollectionChanged += MonsterDataOnCollectionChanged;
+                vm.FilteredIntrinsicData.CollectionChanged += IntrinsicDataOnCollectionChanged;
+            }
+        }
+
+        protected override void OnDetachedFromLogicalTree(LogicalTreeAttachmentEventArgs e)
+        {
+            base.OnDetachedFromLogicalTree(e);
+            if (DataContext is TeamMemberSpawnModel vm)
+            {
+                vm.FilteredSkillData.CollectionChanged -= FilteredSkillDataOnCollectionChanged;
+                vm.FilteredMonsterForms.CollectionChanged -= MonsterDataOnCollectionChanged;
+                vm.FilteredIntrinsicData.CollectionChanged -= IntrinsicDataOnCollectionChanged;
+            }
+        }
+        
+        private void MonsterDataOnCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+        {
+            TeamMemberSpawnModel vm = DataContext as TeamMemberSpawnModel;
+            if (vm.FinishedAdding)
+            {
+                UpdateMonsterHighlight();
+            }
+        }
+        
+        private void FilteredSkillDataOnCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+        {
+            TeamMemberSpawnModel vm = DataContext as TeamMemberSpawnModel;
+            if (vm.FinishedAdding)
+            {
+                UpdateSkillHighlights();
+            }
+        }
+        
+        private void IntrinsicDataOnCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+        {
+            TeamMemberSpawnModel vm = DataContext as TeamMemberSpawnModel;
+            if (vm.FinishedAdding)
+            {
+                UpdateIntrinsicHighlights();
+            }
+        }
+        
+        private TemplatedControl FocusNextTextBox()
+        {
+            TeamMemberSpawnModel vm = (TeamMemberSpawnModel) DataContext;
+            vm.SetFocusIndex(Math.Min(vm.FocusIndex + 1, _focusOrder.Count - 1));
+            string nextTextbox = _focusOrder[vm.FocusIndex];
+
+            TemplatedControl nextFocus;
+            
+            if (vm.FocusIndex < 6) {
+                nextFocus = this.FindControl<TextBox>(nextTextbox);
+            }
+            else
+            {
+                nextFocus = this.FindControl<NumericUpDown>(nextTextbox);
+            }
+            
+            Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                nextFocus.Focus();
+            });
+            return nextFocus;
+        }
+        
+        private void OnEnter()
+        {
+            TemplatedControl nextFocus = FocusNextTextBox();
+
+            if (nextFocus is TextBox nf)
+            {
+
+                nf.CaretIndex = nf.Text.Length;
+                nf.SelectionStart = 0;
+                nf.SelectionEnd = nf.Text.Length;
+            }
+        }
+        
+        // TODO: For these OnEnterCommands, allows the user to choose the row with arrow keys
+        private void SpeciesTextBox_OnEnterCommand()
+        {
+            TeamMemberSpawnModel vm = (TeamMemberSpawnModel) DataContext;
+ 
+            if (vm.FilteredMonsterForms.Count > 0)
+            {
+                if (vm.SearchMonsterFilter != "")
+                {
+                    vm.SetMonster(vm.FilteredMonsterForms.First().Index);
+                }
+            }
+            
+            OnEnter();
+        }
+        
+        private void SkillTextBox_OnEnterCommand()
+        {
+            TeamMemberSpawnModel vm = DataContext as TeamMemberSpawnModel;
+            if (vm.FilteredSkillData.Count > 0)
+            {
+                if (vm.CurrentSkillSearchFilter != "")
+                {
+                    vm.SetSkill(vm.FilteredSkillData.First());
+                }
+                else
+                {
+                    vm.ResetSkill();
+                }
+            }
+            OnEnter();
+        }
+        
+        private void IntrinsicTextBox_OnEnterCommand()
+        {
+            TeamMemberSpawnModel vm = DataContext as TeamMemberSpawnModel;
+            if (vm.FilteredIntrinsicData.Count > 0)
+            {
+                if (vm.SearchIntrinsicFilter != "")
+                {
+                    vm.SetIntrinsic(vm.FilteredIntrinsicData.First());
+                }
+                else
+                {
+                    vm.ResetSkill();
+                }
+            }
+            OnEnter();
+        }
+        
+        private void SpeciesTextBox_OnGotFocus(object sender, GotFocusEventArgs e)
+        {
+            TeamMemberSpawnModel vm = DataContext as TeamMemberSpawnModel;
+            vm.SetFocusIndex(0);
+        }
+        
+        private void SkillTextBox0_OnGotFocus(object sender, GotFocusEventArgs e)
+        {
+            TeamMemberSpawnModel vm = DataContext as TeamMemberSpawnModel;
+            vm.SetFocusIndex(1);
+            vm.FocusedSkillIndex = 0;
+            vm.UpdateSkillData(vm.SearchSkill0Filter);
+            UpdateSkillHighlights();
+        }
+        
+        private void SkillTextBox1_OnGotFocus(object sender, GotFocusEventArgs e)
+        {
+            TeamMemberSpawnModel vm = DataContext as TeamMemberSpawnModel;
+            vm.SetFocusIndex(2);
+            vm.FocusedSkillIndex = 1;
+            vm.UpdateSkillData(vm.SearchSkill1Filter);
+            UpdateSkillHighlights();
+        }
+
+        private void SkillTextBox2_OnGotFocus(object sender, GotFocusEventArgs e)
+        {
+            TeamMemberSpawnModel vm = DataContext as TeamMemberSpawnModel;
+            vm.SetFocusIndex(3);
+            vm.FocusedSkillIndex = 2;
+            vm.UpdateSkillData(vm.SearchSkill2Filter);
+            UpdateSkillHighlights();;
+        }
+
+        private void SkillTextBox3_OnGotFocus(object sender, GotFocusEventArgs e)
+        {
+            TeamMemberSpawnModel vm = DataContext as TeamMemberSpawnModel;
+            vm.SetFocusIndex(4);
+            vm.FocusedSkillIndex = 3;
+            vm.UpdateSkillData(vm.SearchSkill3Filter);
+            UpdateSkillHighlights();
+        }
+
+        private void IntrinsicTextBox_OnGotFocus(object sender, GotFocusEventArgs e)
+        {
+            TeamMemberSpawnModel vm = DataContext as TeamMemberSpawnModel;
+            vm.SetFocusIndex(5);
+        }
+        
+        // TODO: Currently NumericUpDown doesn't get focused correctly
+        private void MinTextBox_OnGotFocus(object sender, GotFocusEventArgs e)
+        {
+            TeamMemberSpawnModel vm = DataContext as TeamMemberSpawnModel;
+            vm.SetFocusIndex(6);
+        }
+        
+        private void MaxTextBox_OnGotFocus(object sender, GotFocusEventArgs e)
+        {
+            TeamMemberSpawnModel vm = DataContext as TeamMemberSpawnModel;
+            vm.SetFocusIndex(7);
+        }
+        private void SpeciesTextBox_OnLostFocus(object sender, RoutedEventArgs e)
+        {
+            TeamMemberSpawnModel vm = DataContext as TeamMemberSpawnModel;
+            int currFocusIndex = vm.FocusIndex;
+            Dispatcher.UIThread.Post(() =>
+            {
+                if (vm.FilteredMonsterForms.Count > 0 && vm.FocusIndex != currFocusIndex)
+                {
+                    // if (vm.SearchMonsterFilter == "")
+                    // {
+                    //     vm.ResetMonster();
+                    // }
+                    if (vm.SanitizeStringEquals(vm.SearchMonsterFilter, vm.FilteredMonsterForms.First().Name))
+                    {
+                        vm.SetMonster(vm.FilteredMonsterForms.First().Index);
+                    } 
+                }
+            });
+        }
+        
+        private void SkillTextBox0_OnLostFocus(object sender, RoutedEventArgs e)
+        {
+            SkillTextBox_OnLostFocus(0);
+        }
+
+        private void SkillTextBox1_OnLostFocus(object sender, RoutedEventArgs e)
+        {
+            SkillTextBox_OnLostFocus(1);
+        }
+        
+        private void SkillTextBox2_OnLostFocus(object sender, RoutedEventArgs e)
+        {
+            SkillTextBox_OnLostFocus(2);
+        }
+        
+        private void SkillTextBox3_OnLostFocus(object sender, RoutedEventArgs e)
+        {
+            SkillTextBox_OnLostFocus(3);
+        }
+        private void SkillTextBox_OnLostFocus(int index)
+        {
+            TeamMemberSpawnModel vm = DataContext as TeamMemberSpawnModel;
+            SkillDataViewModel skillData = null;
+            
+            int currFocusIndex = vm.FocusIndex;
+            if (vm.FilteredSkillData.Count > 0)
+            {
+                skillData = vm.FilteredSkillData.First();
+            }
+            
+            List<string> skillFilters = new List<string>{ vm.SearchSkill0Filter, vm.SearchSkill1Filter, vm.SearchSkill2Filter, vm.SearchSkill3Filter };
+            string filter = skillFilters[index];
+            Dispatcher.UIThread.Post(() =>
+            {
+                if (skillData != null && vm.FocusIndex != currFocusIndex)
+                {
+                    if (filter == "")
+                    {
+                        vm.ResetSkill(index);
+                    }
+        
+                    else if (vm.SanitizeStringEquals(filter, skillData.Name))
+                    {
+                        vm.SetSkill(skillData, index);
+                    } 
+                }
+            });
+        }
+        
+        private void IntrinsicTextBox_OnLostFocus(object sender, RoutedEventArgs e)
+        {
+            TeamMemberSpawnModel vm = DataContext as TeamMemberSpawnModel;
+            
+            int currFocusIndex = vm.FocusIndex;
+            
+            Dispatcher.UIThread.Post(() =>
+            {
+                if (vm.FilteredIntrinsicData.Count > 0 && vm.FocusIndex != currFocusIndex)
+                {
+                    if (vm.SearchIntrinsicFilter == "")
+                    {
+                        vm.ResetIntrinsic();
+                    }
+                    else if (vm.SanitizeStringEquals(vm.SearchIntrinsicFilter, vm.FilteredIntrinsicData.First().Name))
+                    {
+                        vm.SetIntrinsic(vm.FilteredIntrinsicData.First());
+                    } 
+                }
+            });
+        }
+        
+        private void MonsterDataGrid_OnCellPointerPressed(object sender, DataGridCellPointerPressedEventArgs e)
+        {
+            TeamMemberSpawnModel vm = DataContext as TeamMemberSpawnModel;
+            BaseMonsterFormViewModel dataContext = (BaseMonsterFormViewModel)e.Cell.DataContext;
+            vm.SetMonster(dataContext.Index);
+            FocusNextTextBox();
+        }
+        
+        private void SkillsDataGrid_OnCellPointerPressed(object sender, DataGridCellPointerPressedEventArgs e)
+        {
+            TeamMemberSpawnModel vm = DataContext as TeamMemberSpawnModel;
+            SkillDataViewModel skillData = (SkillDataViewModel)e.Cell.DataContext;
+            vm.SetSkill(skillData);
+            FocusNextTextBox();
+        }
+        private void IntrinsicDataGrid_OnCellPointerPressed(object sender, DataGridCellPointerPressedEventArgs e)
+        {
+            TeamMemberSpawnModel vm = DataContext as TeamMemberSpawnModel;
+            IntrinsicViewModel intrinsicData = (IntrinsicViewModel)e.Cell.DataContext;
+            vm.SetIntrinsic(intrinsicData);
+            FocusNextTextBox();
+        }
+        
+        private void UpdateMonsterHighlight()
+        {
+            TeamMemberSpawnModel vm = DataContext as TeamMemberSpawnModel;
+            int index = vm.SelectedMonsterIndex;
+            if (vm.FilteredMonsterForms.Count > 0 && vm.SearchMonsterFilter != null)
+            {
+                BaseMonsterFormViewModel monsterData = vm.MonsterAtIndex(index);
+                if (vm.ShouldAddToFilter(monsterData.Name, vm.SearchMonsterFilter) &&
+                    (vm.IncludeUnreleasedForms || monsterData.Released))
+                {
+                    vm.SelectedMonsterForm = monsterData;
+                }
+            }
+        }
+
+        private void UpdateSkillHighlights()
+        {
+            TeamMemberSpawnModel vm = DataContext as TeamMemberSpawnModel;
+            DataGrid datagrid = this.FindControl<DataGrid>("SkillsDataGrid");
+            datagrid.SelectedItems.Clear();
+            foreach (int index in vm.SkillIndex)
+            {
+                if (index != -1 && vm.FilteredSkillData.Count > 0)
+                {
+                    SkillDataViewModel skillData = vm.SkillDataAtIndex(index);
+                    if (vm.ShouldAddToFilter(skillData.Name, vm.CurrentSkillSearchFilter) && (vm.IncludeUnreleasedSkills || skillData.Released))
+                    {
+                        datagrid.SelectedItems.Add(skillData);
+                    }
+                }
+            }
+        
+        }
+        
+        private void UpdateIntrinsicHighlights()
+        {
+            TeamMemberSpawnModel vm = DataContext as TeamMemberSpawnModel;
+            int index = vm.SelectedIntrinsicIndex;
+            if (vm.SelectedIntrinsicIndex != -1 && vm.FilteredIntrinsicData.Count > 0 && vm.SearchIntrinsicFilter != null)
+            {
+                IntrinsicViewModel intrinsicData = vm.IntrinsicAtIndex(index);
+                if (vm.ShouldAddToFilter(intrinsicData.Name, vm.SearchIntrinsicFilter) && (vm.IncludeUnreleasedIntrinsics || intrinsicData.Released))
+                {
+                    vm.SelectedIntrinsic = intrinsicData;
+                }
+            }
+        }
+
+        private void MinTextBox_OnValueChanged(object sender, NumericUpDownValueChangedEventArgs e)
+        {
+            NumericUpDown nudMin = (NumericUpDown)sender;
+            NumericUpDown nudMax = this.FindControl<NumericUpDown>("MaxTextBox");
+            
+            if (nudMin.Value > nudMax.Value)
+                nudMax.Value = nudMin.Value;
+        }
+        
+        private void MaxTextBox_OnValueChanged(object sender, NumericUpDownValueChangedEventArgs e)
+        {
+            NumericUpDown nudMin = this.FindControl<NumericUpDown>("MinTextBox");
+            NumericUpDown nudMax = (NumericUpDown)sender;
+      
+            
+            if (nudMin.Value > nudMax.Value)
+                nudMin.Value = nudMax.Value;
+        }
+    }
+}

--- a/PMDC/Dev/Views/UserControls/TeamMemberSpawnView.axaml.cs
+++ b/PMDC/Dev/Views/UserControls/TeamMemberSpawnView.axaml.cs
@@ -221,14 +221,14 @@ namespace PMDC.Dev.Views
         // TODO: Currently NumericUpDown doesn't get focused correctly
         private void MinTextBox_OnGotFocus(object sender, GotFocusEventArgs e)
         {
-            TeamMemberSpawnModel vm = DataContext as TeamMemberSpawnModel;
-            vm.SetFocusIndex(6);
+            // TeamMemberSpawnModel vm = DataContext as TeamMemberSpawnModel;
+            // vm.SetFocusIndex(6);
         }
         
         private void MaxTextBox_OnGotFocus(object sender, GotFocusEventArgs e)
         {
-            TeamMemberSpawnModel vm = DataContext as TeamMemberSpawnModel;
-            vm.SetFocusIndex(7);
+            // TeamMemberSpawnModel vm = DataContext as TeamMemberSpawnModel;
+            // vm.SetFocusIndex(7);
         }
         private void SpeciesTextBox_OnLostFocus(object sender, RoutedEventArgs e)
         {

--- a/PMDC/Program.cs
+++ b/PMDC/Program.cs
@@ -30,6 +30,7 @@ namespace PMDC
         //[System.Runtime.InteropServices.DllImport("user32.dll")]
         //static extern bool SetProcessDPIAware();
 
+        public static AppBuilder BuildAvaloniaApp() => RogueEssence.Dev.Program.BuildAvaloniaApp();
         /// <summary>
         /// The main entry point for the application.
         /// </summary>
@@ -599,7 +600,7 @@ namespace PMDC
                 if (DiagManager.Instance.DevMode)
                 {
                     InitDataEditor();
-                    AppBuilder builder = RogueEssence.Dev.Program.BuildAvaloniaApp();
+                    AppBuilder builder = BuildAvaloniaApp();
                     builder.StartWithClassicDesktopLifetime(args);
                 }
                 else
@@ -631,7 +632,6 @@ namespace PMDC
         public static void InitDataEditor()
         {
             DataEditor.Init();
-
             DataEditor.AddEditor(new StatusEffectEditor());
             DataEditor.AddEditor(new MapStatusEditor());
 
@@ -692,8 +692,10 @@ namespace PMDC
             DataEditor.AddEditor(new PromoteBranchEditor());
 
             DataEditor.AddEditor(new MonsterIDEditor());
-
+            
             DataEditor.AddEditor(new TeamMemberSpawnEditor());
+            DataEditor.AddEditor(new TeamMemberSpawnSimpleEditor());
+
             DataEditor.AddEditor(new MobSpawnEditor());
             DataEditor.AddEditor(new MobSpawnWeakEditor());
             DataEditor.AddEditor(new MobSpawnAltColorEditor());


### PR DESCRIPTION
New editor for TeamMemberSpawn--similar to Showdown

Minor Bugs
- Selected skills are not highlighted when you click on one of the skill textbox. They will be rehighlighted if you focus off and then focus back to the textbox
- Scrollbar disappears when you click on the either the min or max textbox
- As of currently, NumericUpDown doesn't focus correctly, possibly fixed in this PR:
https://github.com/AvaloniaUI/Avalonia/pull/13376
- Simple & Advanced functionality in findEditor doesn't exactly work yet

Other Desire Features (not yet implemented, but could be)
- Type filters for moves and mons
- Show all valid moves even though you have the move chosen already (Showdown behavior)

Code practices probably needs a lot of improvement, especially with the way how I handled setting the skills and selecting them. I feel like lots of things can be abstracted also

Requirements:

Adding Assets + Shift-Click Advance Editor Implementation
https://github.com/RogueCollab/RogueEssence/pull/123 

Assets for Editor:
https://github.com/audinowho/DumpAsset/pull/72/files

New:

<img width="1385" height="878" alt="Screenshot 2026-01-10 at 2 09 15 PM" src="https://github.com/user-attachments/assets/fa147c03-a0e4-498e-96e7-be4121194174" />


Old:

<img width="1385" height="878" alt="Screenshot 2026-01-10 at 2 10 04 PM" src="https://github.com/user-attachments/assets/f6590490-ae60-4cfa-8307-dd4024838711" />


