### PR TITLE
add exp yield + recruitment rate, non-verbose tactics

### DIFF
--- a/PMDC/Dev/ViewModels/TeamMemberSpawn/BaseMonsterFormViewModel.cs
+++ b/PMDC/Dev/ViewModels/TeamMemberSpawn/BaseMonsterFormViewModel.cs
@@ -18,6 +18,8 @@ namespace PMDC.Dev.ViewModels
             
             this.key = key;
             this.formId = formId;
+            this.joinRate = data.JoinRate;
+            
             Index = index;
         }
         
@@ -122,6 +124,24 @@ namespace PMDC.Dev.ViewModels
             { 
                 return monsterForm.BaseHP + monsterForm.BaseAtk + monsterForm.BaseDef +
                      monsterForm.BaseMAtk +  monsterForm.BaseMDef +  monsterForm.BaseSpeed;
+            }
+        }
+
+        private int joinRate;
+
+        public int JoinRate
+        {
+            get
+            {
+                return joinRate;
+            }
+        }
+        
+        public int ExpYield
+        {
+            get
+            {
+                return monsterForm.ExpYield;
             }
         }
     }

--- a/PMDC/Dev/ViewModels/TeamMemberSpawn/TeamMemberSpawnModel.cs
+++ b/PMDC/Dev/ViewModels/TeamMemberSpawn/TeamMemberSpawnModel.cs
@@ -463,13 +463,13 @@ namespace PMDC.Dev.ViewModels
         {
             BaseMonsterFormViewModel vm = monsterForms[index];
             
+            SetFormPossibleIntrinsics(vm.Key, vm.FormId);
+            updateIntrinsicData(_searchIntrinsicFilter);
             _applySearch = false;
             SelectedMonsterForm = vm;
             TeamSpawn.Spawn.BaseForm.Form = vm.FormId;
             TeamSpawn.Spawn.BaseForm.Species = vm.Key;
             SetFormPossibleSkills(vm.Key, vm.FormId);
-            SetFormPossibleIntrinsics(vm.Key, vm.FormId);
-            updateIntrinsicData(_searchIntrinsicFilter);
             SkillIndex = new List<int> { -1, -1, -1, -1 };
             TeamSpawn.Spawn.SpecifiedSkills = new List<string>();
             SearchSkill0Filter = "";
@@ -730,7 +730,7 @@ namespace PMDC.Dev.ViewModels
         private void InitializeTactics()
         {
             Tactics = new ObservableCollection<string>();
-            Dictionary<string, string> tacticNames = DataManager.Instance.DataIndices[DataManager.DataType.AI].GetLocalStringArray(true);
+            Dictionary<string, string> tacticNames = DataManager.Instance.DataIndices[DataManager.DataType.AI].GetLocalStringArray();
 
             tacticKeys = new List<string>();
 

--- a/PMDC/Dev/Views/UserControls/TeamMemberSpawnView.axaml
+++ b/PMDC/Dev/Views/UserControls/TeamMemberSpawnView.axaml
@@ -295,6 +295,8 @@
                         <DataGridTextColumn Header="SpD" CellStyleClasses="center_column" Binding="{Binding BaseMDef}" Width="Auto" />
                         <DataGridTextColumn Header="Spe" CellStyleClasses="center_column" Binding="{Binding BaseSpeed}" Width="Auto" />
                         <DataGridTextColumn Header="BST" CellStyleClasses="center_column" Binding="{Binding BaseTotal}" Width="Auto" />
+                        <DataGridTextColumn Header="EXP Yield" CellStyleClasses="center_column" Binding="{Binding ExpYield}" Width="Auto" />
+                        <DataGridTextColumn Header="Join Rate" CellStyleClasses="center_column" Binding="{Binding JoinRate}" Width="Auto" />
                     </DataGrid.Columns>
                 </DataGrid>
             </Grid>


### PR DESCRIPTION
PR does three things:

- Adds the Recruitment Rate and Exp Yield data
- Fixes a bug with ability not updating immediately after clicking on a new mon then clicking on the ability textbox
- Makes tactics non-verbose. Verbose tactics can cause the tactic textbox to expand which can messes up the layout of the editor, especially if the comments for the tactic is long